### PR TITLE
Fetch segue version using config module

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
@@ -146,7 +146,7 @@ public class IsaacApplicationRegister extends Application {
 
         Info apiInfo = new Info()
                 .title("Isaac API")
-                .version(propertiesLoader.getProperty(SEGUE_APP_VERSION))
+                .version(SegueGuiceConfigurationModule.getSegueVersion())
                 .description("API for the Isaac platform. Automated use may violate our Terms of Service.")
                 .contact(new Contact()
                         .name(propertiesLoader.getProperty(MAIL_NAME))


### PR DESCRIPTION
This change came from this warning I noticed this in the startup logs:
```
[2022-12-28 00:01:58] [WARN ] PropertiesLoader:74 - Failed to resolve requested property with key: SEGUE_APP_VERSION, /local/data/conf/segue-config.properties
```