### PR TITLE
 Remove content indices from container in favor of configmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,6 @@ RUN mkdir /isaac-logs
 RUN chmod 755 /isaac-logs
 RUN chown jetty /isaac-logs
 ADD resources/school_list_2022.tar.gz /local/data/
-COPY config-templates/content_indices.cs.properties /local/data/content-indices.properties
-RUN chmod 755 /local/data/content-indices.properties
-RUN chown jetty /local/data/content-indices.properties
 COPY --from=base /isaac-api/target/isaac-api.war /var/lib/jetty/webapps/isaac-api.war
 RUN chmod 755 /var/lib/jetty/webapps/*
 RUN chown jetty /var/lib/jetty/webapps/*


### PR DESCRIPTION
A config map will be used instead so it won't be necessary to cut a new docker image for each content update.