### PR TITLE
Merging lone upstream commit

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -1009,7 +1009,7 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
             // are currently configured, so the constructor takes a list of jobs to remove too.
             List<SegueScheduledJob> scheduledJobsToRemove = new ArrayList<>();
 
-            if (mailjetKey != null && mailjetSecret != null) {
+            if (null != mailjetKey && null != mailjetSecret && !mailjetKey.isEmpty() && !mailjetSecret.isEmpty()) {
                 configuredScheduledJobs.add(syncMailjetUsers);
             } else {
                 scheduledJobsToRemove.add(syncMailjetUsers);


### PR DESCRIPTION
Commit message:
Use consistent settings check for MailJet sync job
The stub manager was used in the case that the properties were null or the empty string, but the job was scheduled if the properties were non-null. This meant the job could be scheduled to be run by the stub manager that would immediately error out.