### PR TITLE
Robert/15 weak password prevention

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,6 +440,12 @@
             <version>${netty.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
@@ -439,12 +445,6 @@
             <artifactId>netty-all</artifactId>
             <version>${netty.version}</version>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>5.9.2</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -321,6 +321,8 @@ public final class Constants {
     public static final String LOCAL_AUTH_EMAIL_VERIFICATION_TOKEN_FIELDNAME = "emailVerificationToken";
     public static final String LOCAL_AUTH_GROUP_MANAGER_INITIATED_FIELDNAME = "groupManagerInitiated";
     public static final String LOCAL_AUTH_GROUP_MANAGER_EMAIL_FIELDNAME = "groupManagerEmail";
+    public static final String PASSWORD_REQUIREMENTS_ERROR_MESSAGE = "Password must be at least 12 characters in length and contain at least one of each of: uppercase character, lowercase character, number and ascii punctuation character.";
+
 
     // Database properties
     public static final String SEGUE_DB_NAME = "SEGUE_DB_NAME";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
@@ -244,13 +244,9 @@ public class SegueLocalAuthenticator implements IPasswordAuthenticator {
         if (null == password || password.isEmpty()) {
             throw new InvalidPasswordException("Invalid password. You cannot have an empty password.");
         }
-
-        if (password.length() < MINIMUM_PASSWORD_LENGTH) {
-            throw new InvalidPasswordException("Password must be at least 12 characters in length.");
-        }
         
-        if (!password.matches("^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[ !\"#$%&'()*+,\\-./:;<=>?@\\[\\]\\^_`\\{\\|\\}~]).{" + MINIMUM_PASSWORD_LENGTH + ",}$")) {
-            throw new InvalidPasswordException("Password must contain at least one of each of: uppercase character, lowercase character, number, special character.");
+        if (!password.matches("^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*\\p{P}).{" + MINIMUM_PASSWORD_LENGTH + ",}$")) {
+            throw new InvalidPasswordException("Password must be at least 12 characters in length and contain at least one of each of: uppercase character, lowercase character, number and ascii punctuation character.");
         }
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
@@ -50,6 +50,7 @@ import com.google.inject.Inject;
 public class SegueLocalAuthenticator implements IPasswordAuthenticator {
     private static final Logger log = LoggerFactory.getLogger(SegueLocalAuthenticator.class);
     private static final Integer SHORT_KEY_LENGTH = 128;
+    private static final Integer MINIMUM_PASSWORD_LENGTH = 12;
 
     private final IPasswordDataManager passwordDataManager;
     private final IUserDataManager userDataManager;
@@ -244,12 +245,11 @@ public class SegueLocalAuthenticator implements IPasswordAuthenticator {
             throw new InvalidPasswordException("Invalid password. You cannot have an empty password.");
         }
 
-        if (password.length() < 12) {
+        if (password.length() < MINIMUM_PASSWORD_LENGTH) {
             throw new InvalidPasswordException("Password must be at least 12 characters in length.");
         }
-
-        //  Special characters: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
-        if (!password.matches("^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[ !\"#$%&'()*+,\\-./:;<=>?@\\[\\]\\^_`\\{\\|\\}~]).{12,}$")) {
+        
+        if (!password.matches("^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[ !\"#$%&'()*+,\\-./:;<=>?@\\[\\]\\^_`\\{\\|\\}~]).{" + MINIMUM_PASSWORD_LENGTH + ",}$")) {
             throw new InvalidPasswordException("Password must contain at least one of each of: uppercase character, lowercase character, number, special character.");
         }
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
@@ -244,8 +244,13 @@ public class SegueLocalAuthenticator implements IPasswordAuthenticator {
             throw new InvalidPasswordException("Invalid password. You cannot have an empty password.");
         }
 
-        if (password.length() < 6) {
-            throw new InvalidPasswordException("Password must be at least 6 characters in length.");
+        if (password.length() < 12) {
+            throw new InvalidPasswordException("Password must be at least 12 characters in length.");
+        }
+
+        //  Special characters: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+        if (password.matches("^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[ !\"#$%&'()*+,\\-./:;<=>?@\\[\\\\]\\^_`\\{\\|\\}~)")) {
+            throw new InvalidPasswordException("Password must contain at least one of each of: uppercase character, lowercase character, number, special character.");
         }
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
@@ -249,7 +249,7 @@ public class SegueLocalAuthenticator implements IPasswordAuthenticator {
         }
 
         //  Special characters: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
-        if (password.matches("^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[ !\"#$%&'()*+,\\-./:;<=>?@\\[\\\\]\\^_`\\{\\|\\}~)")) {
+        if (!password.matches("^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[ !\"#$%&'()*+,\\-./:;<=>?@\\[\\]\\^_`\\{\\|\\}~]).{12,}$")) {
             throw new InvalidPasswordException("Password must contain at least one of each of: uppercase character, lowercase character, number, special character.");
         }
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
@@ -16,6 +16,7 @@
 package uk.ac.cam.cl.dtg.segue.auth;
 
 import static uk.ac.cam.cl.dtg.segue.api.Constants.HMAC_SALT;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.PASSWORD_REQUIREMENTS_ERROR_MESSAGE;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -246,7 +247,7 @@ public class SegueLocalAuthenticator implements IPasswordAuthenticator {
         }
         
         if (!password.matches("^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*\\p{P}).{" + MINIMUM_PASSWORD_LENGTH + ",}$")) {
-            throw new InvalidPasswordException("Password must be at least 12 characters in length and contain at least one of each of: uppercase character, lowercase character, number and ascii punctuation character.");
+            throw new InvalidPasswordException(PASSWORD_REQUIREMENTS_ERROR_MESSAGE);
         }
     }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
@@ -38,11 +38,11 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.easymock.EasyMock.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class for the SegueLocalAuthenticator class.
- * 
+ *
  */
 public class SegueLocalAuthenticatorTest {
 
@@ -83,18 +83,18 @@ public class SegueLocalAuthenticatorTest {
 		RegisteredUser someUser = new RegisteredUser();
 		someUser.setEmail("test@test.com");
 		someUser.setId(533L);
-		
+
 		replay(userDataManager);
-		
+
 		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
 		        this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
-		
+
 		try {
 			segueAuthenticator.setOrChangeUsersPassword(someUser, null);
 			fail("Expected InvalidPasswordException to be thrown as a null password was given.");
 		} catch (InvalidPasswordException e) {
 			// this is a pass
-			
+
 		} catch (SegueDatabaseException e) {
 			e.printStackTrace();
 		}
@@ -104,12 +104,12 @@ public class SegueLocalAuthenticatorTest {
 			fail("Expected InvalidPasswordException to be thrown as a empty password was given.");
 		} catch (InvalidPasswordException e) {
 			// this is a pass
-			
+
 		} catch (SegueDatabaseException e) {
 			e.printStackTrace();
 		}
 	}
-	
+
 	/**
 	 * Verify that setOrChangeUsersPassword works with correct input and the
 	 * result is a user object with base64 encoded passwords and a secure salt.
@@ -121,27 +121,27 @@ public class SegueLocalAuthenticatorTest {
 		someUser.setId(533L);
 		String somePassword = "test5eguePassw0rd!";
 		replay(userDataManager);
-		
+
 		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
 				this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
-		
+
 		try {
 			segueAuthenticator.setOrChangeUsersPassword(someUser, somePassword);
-			
+
 			//TODO write test
-			
+
 		} catch (InvalidPasswordException e) {
 			fail("This should be a valid password");
 		} catch (SegueDatabaseException e) {
 			e.printStackTrace();
 		}
 	}
-	
+
 	/**
 	 * Verify that setOrChangeUsersPassword fails on a bad password.
-	 * @throws SegueDatabaseException 
-	 * @throws NoCredentialsAvailableException 
-	 * @throws NoUserException 
+	 * @throws SegueDatabaseException
+	 * @throws NoCredentialsAvailableException
+	 * @throws NoUserException
 	 */
 	@Test
 	public final void segueLocalAuthenticator_authenticate_correctEmailAndIncorrectPasswordProvided()
@@ -149,7 +149,7 @@ public class SegueLocalAuthenticatorTest {
 		String someCorrectPasswordHashFromDB = "q41e8iZsi0TO5xB1MWwC06jkaWx8MTnSHMp3eP/FNOTBCwpTnPX5a/KsUTUJ2cwnCiXZeATVqWEF2FCbSQp9Fg==";
 		String someCorrectSecureSaltFromDB = "P77Fhqu2/SAVGDCtu9IkHg==";
 		String usersEmailAddress = "test@test.com";
-		
+
 		RegisteredUser userFromDatabase = new RegisteredUser();
 		userFromDatabase.setId(533L);
 		userFromDatabase.setEmail(usersEmailAddress);
@@ -169,61 +169,61 @@ public class SegueLocalAuthenticatorTest {
         expect(passwordDataManager.getLocalUserCredential(anyLong())).andReturn(luc).atLeastOnce();
 
 		replay(userDataManager, passwordDataManager);
-		
+
 		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
 				this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
 		try {
 			RegisteredUser authenticatedUser = segueAuthenticator.authenticate(usersEmailAddress, someIncorrectPassword);
 			fail("This should fail as a bad password has been provided.");
-			
+
 		} catch (IncorrectCredentialsProvidedException e) {
 			// success
-			
-		}		
+
+		}
 	}
-	
+
 	/**
 	 * Verify that setOrChangeUsersPassword fails on a bad e-mail and password.
-	 * @throws SegueDatabaseException 
-	 * @throws IncorrectCredentialsProvidedException 
-	 * @throws NoCredentialsAvailableException 
-	 * @throws NoUserException 
+	 * @throws SegueDatabaseException
+	 * @throws IncorrectCredentialsProvidedException
+	 * @throws NoCredentialsAvailableException
+	 * @throws NoUserException
 	 */
 	@Test
 	public final void segueLocalAuthenticator_authenticate_badEmailAndIncorrectPasswordProvided()
 			throws SegueDatabaseException, IncorrectCredentialsProvidedException,
 			NoCredentialsAvailableException, InvalidKeySpecException, NoSuchAlgorithmException {
 		String usersEmailAddress = "test@test.com";
-		
+
 		RegisteredUser userFromDatabase = new RegisteredUser();
 		userFromDatabase.setId(533L);
 		userFromDatabase.setEmail(usersEmailAddress);
-		
+
 		String someBadEmail = "badtest@test.com";
 		String someIncorrectPassword = "password";
-		
+
 		expect(userDataManager.getByEmail(someBadEmail)).andReturn(null).once();
-		
+
 		replay(userDataManager);
-		
+
 		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
 				this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
 		try {
 			RegisteredUser authenticatedUser = segueAuthenticator.authenticate(someBadEmail, someIncorrectPassword);
 			fail("This should fail as a bad email and password has been provided.");
-			
+
 		} catch (NoUserException e) {
 			// success. This is what we expect.
-		} 
+		}
 	}
-	
+
 	/**
 	 * Verify that the authenticator creates and authenticates correctly..
-	 * @throws SegueDatabaseException 
-	 * @throws IncorrectCredentialsProvidedException 
-	 * @throws NoCredentialsAvailableException 
-	 * @throws InvalidPasswordException 
-	 * @throws NoUserException 
+	 * @throws SegueDatabaseException
+	 * @throws IncorrectCredentialsProvidedException
+	 * @throws NoCredentialsAvailableException
+	 * @throws InvalidPasswordException
+	 * @throws NoUserException
 	 */
 	@Test
 	public final void segueLocalAuthenticator_setPasswordAndImmediateAuthenticate_correctEmailAndPasswordProvided()
@@ -248,20 +248,20 @@ public class SegueLocalAuthenticatorTest {
 		expect(passwordDataManager.createOrUpdateLocalUserCredential(anyObject())).andReturn(luc).atLeastOnce();
 
 		replay(userDataManager, passwordDataManager);
-		
+
 		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
 				this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
 		try {
 			// first try and mutate the user object using the the set method.
 			// this should set the password and secure hash on the user object.
 			segueAuthenticator.setOrChangeUsersPassword(userFromDatabase, someCorrectPasswordPlainText);
-			
+
 			// now try and authenticate using the password we just created.
 			RegisteredUser authenticatedUser = segueAuthenticator.authenticate(usersEmailAddress, someCorrectPasswordPlainText);
 
 		} catch (NoUserException e) {
 			fail("We expect a user to be returned");
-		} 
+		}
 	}
 
 	@Test

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
@@ -16,8 +16,11 @@
 package uk.ac.cam.cl.dtg.segue.auth;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.ac.cam.cl.dtg.isaac.dos.users.LocalUserCredential;
 import uk.ac.cam.cl.dtg.isaac.dos.users.RegisteredUser;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.IncorrectCredentialsProvidedException;
@@ -32,13 +35,10 @@ import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Map;
+import java.util.stream.Stream;
 
-import static org.easymock.EasyMock.anyLong;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.fail;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
 
 /**
  * Test class for the SegueLocalAuthenticator class.
@@ -68,7 +68,7 @@ public class SegueLocalAuthenticatorTest {
 	 * @throws Exception
 	 *             - test exception
 	 */
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		this.userDataManager = createMock(IUserDataManager.class);
 		this.passwordDataManager = createMock(IPasswordDataManager.class);
@@ -119,7 +119,7 @@ public class SegueLocalAuthenticatorTest {
 		RegisteredUser someUser = new RegisteredUser();
 		someUser.setEmail("test@test.com");
 		someUser.setId(533L);
-		String somePassword = "test5eguePassw0rd";
+		String somePassword = "test5eguePassw0rd!";
 		replay(userDataManager);
 		
 		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
@@ -146,8 +146,8 @@ public class SegueLocalAuthenticatorTest {
 	@Test
 	public final void segueLocalAuthenticator_authenticate_correctEmailAndIncorrectPasswordProvided()
 			throws SegueDatabaseException, NoUserException, NoCredentialsAvailableException, InvalidKeySpecException, NoSuchAlgorithmException {
-		String someCorrectPasswordPlainText = "test5eguePassw0rd";
-		String someCorrectPasswordHashFromDB = "NyACfIYjYUGK7EbtlMAV48+dgyXpa+DPUKHmR1IjY/nAI2xydZUuqtVYc/shQnJ9fhquDOu56C57NGUPsxJ52Q==";
+		String someCorrectPasswordPlainText = "test5eguePassw0rd!";
+		String someCorrectPasswordHashFromDB = "q41e8iZsi0TO5xB1MWwC06jkaWx8MTnSHMp3eP/FNOTBCwpTnPX5a/KsUTUJ2cwnCiXZeATVqWEF2FCbSQp9Fg==";
 		String someCorrectSecureSaltFromDB = "P77Fhqu2/SAVGDCtu9IkHg==";
 		String usersEmailAddress = "test@test.com";
 		
@@ -194,8 +194,8 @@ public class SegueLocalAuthenticatorTest {
 	public final void segueLocalAuthenticator_authenticate_badEmailAndIncorrectPasswordProvided()
 			throws SegueDatabaseException, IncorrectCredentialsProvidedException,
 			NoCredentialsAvailableException, InvalidKeySpecException, NoSuchAlgorithmException {
-		String someCorrectPasswordPlainText = "test5eguePassw0rd";
-		String someCorrectPasswordHashFromDB = "NyACfIYjYUGK7EbtlMAV48+dgyXpa+DPUKHmR1IjY/nAI2xydZUuqtVYc/shQnJ9fhquDOu56C57NGUPsxJ52Q==";
+		String someCorrectPasswordPlainText = "test5eguePassw0rd!";
+		String someCorrectPasswordHashFromDB = "q41e8iZsi0TO5xB1MWwC06jkaWx8MTnSHMp3eP/FNOTBCwpTnPX5a/KsUTUJ2cwnCiXZeATVqWEF2FCbSQp9Fg==";
 		String someCorrectSecureSaltFromDB = "P77Fhqu2/SAVGDCtu9IkHg==";
 		String usersEmailAddress = "test@test.com";
 		
@@ -233,9 +233,9 @@ public class SegueLocalAuthenticatorTest {
 	public final void segueLocalAuthenticator_setPasswordAndImmediateAuthenticate_correctEmailAndPasswordProvided()
 			throws SegueDatabaseException, IncorrectCredentialsProvidedException,
 			NoCredentialsAvailableException, InvalidPasswordException, InvalidKeySpecException, NoSuchAlgorithmException {
-		String someCorrectPasswordPlainText = "test5eguePassw0rd";
+		String someCorrectPasswordPlainText = "test5eguePassw0rd!";
 		String usersEmailAddress = "test@test.com";
-        String someCorrectPasswordHashFromDB = "NyACfIYjYUGK7EbtlMAV48+dgyXpa+DPUKHmR1IjY/nAI2xydZUuqtVYc/shQnJ9fhquDOu56C57NGUPsxJ52Q==";
+        String someCorrectPasswordHashFromDB = "q41e8iZsi0TO5xB1MWwC06jkaWx8MTnSHMp3eP/FNOTBCwpTnPX5a/KsUTUJ2cwnCiXZeATVqWEF2FCbSQp9Fg==";
         String someCorrectSecureSaltFromDB = "P77Fhqu2/SAVGDCtu9IkHg==";
 
 		RegisteredUser userFromDatabase = new RegisteredUser();
@@ -266,5 +266,41 @@ public class SegueLocalAuthenticatorTest {
 		} catch (NoUserException e) {
 			fail("We expect a user to be returned");
 		} 
+	}
+
+	@Test
+	public void ensureValidPassword_validString() {
+		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
+				this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
+		try {
+			segueAuthenticator.ensureValidPassword("Password123!");
+		} catch (InvalidPasswordException e) {
+			fail("We expect this password to be accepted as valid");
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("ensureValidPassword_invalidStrings")
+	public void ensureValidPassword_invalidStrings(String password, String expectedMessage) {
+		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
+				this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
+		Exception exception = assertThrows(InvalidPasswordException.class, () -> segueAuthenticator.ensureValidPassword(password));
+		assertEquals(expectedMessage, exception.getMessage());
+	}
+
+	private static Stream<Arguments> ensureValidPassword_invalidStrings() {
+		return Stream.of(
+				Arguments.of(null, "Invalid password. You cannot have an empty password."), // Null is invalid
+				Arguments.of("", "Invalid password. You cannot have an empty password."), // Empty string is invalid
+				Arguments.of("password123", "Password must be at least 12 characters in length."), // Password must equal or exceed the minimum length
+				// Password must contain an upper case letter
+				Arguments.of("password123!", "Password must contain at least one of each of: uppercase character, lowercase character, number, special character."),
+				// Password must contain a lower case letter
+				Arguments.of("PASSWORD123!", "Password must contain at least one of each of: uppercase character, lowercase character, number, special character."),
+				// Password must contain a number
+				Arguments.of("Passwordabc!", "Password must contain at least one of each of: uppercase character, lowercase character, number, special character."),
+				// Password must contain a special character
+				Arguments.of("Password1234", "Password must contain at least one of each of: uppercase character, lowercase character, number, special character.")
+		);
 	}
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
@@ -62,6 +62,9 @@ public class SegueLocalAuthenticatorTest {
             oldAlgorithm3.hashingAlgorithmName(), oldAlgorithm3
     );
 
+	private static final String PASSWORD_REQUIREMENTS_ERROR_MESSAGE = "Password must be at least 12 characters in length and contain at least one of each of: uppercase character, lowercase character, number and ascii punctuation character.";
+
+
 	/**
 	 * Initial configuration of tests.
 	 *
@@ -307,15 +310,15 @@ public class SegueLocalAuthenticatorTest {
 		return Stream.of(
 				Arguments.of(null, "Invalid password. You cannot have an empty password."), // Null is invalid
 				Arguments.of("", "Invalid password. You cannot have an empty password."), // Empty string is invalid
-				Arguments.of("password123", "Password must be at least 12 characters in length."), // Password must equal or exceed the minimum length
+				Arguments.of("password123", PASSWORD_REQUIREMENTS_ERROR_MESSAGE), // Password must equal or exceed the minimum length
 				// Password must contain an upper case letter
-				Arguments.of("password123!", "Password must contain at least one of each of: uppercase character, lowercase character, number, special character."),
+				Arguments.of("password123!", PASSWORD_REQUIREMENTS_ERROR_MESSAGE),
 				// Password must contain a lower case letter
-				Arguments.of("PASSWORD123!", "Password must contain at least one of each of: uppercase character, lowercase character, number, special character."),
+				Arguments.of("PASSWORD123!", PASSWORD_REQUIREMENTS_ERROR_MESSAGE),
 				// Password must contain a number
-				Arguments.of("Passwordabc!", "Password must contain at least one of each of: uppercase character, lowercase character, number, special character."),
+				Arguments.of("Passwordabc!", PASSWORD_REQUIREMENTS_ERROR_MESSAGE),
 				// Password must contain a special character
-				Arguments.of("Password1234", "Password must contain at least one of each of: uppercase character, lowercase character, number, special character.")
+				Arguments.of("Password1234", PASSWORD_REQUIREMENTS_ERROR_MESSAGE)
 		);
 	}
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
@@ -77,6 +77,8 @@ public class SegueLocalAuthenticatorTest {
 
 	/**
 	 * Verify that setOrChangeUsersPassword fails with bad input.
+	 * @throws InvalidKeySpecException
+	 * @throws NoSuchAlgorithmException
 	 */
 	@Test
 	public final void segueLocalAuthenticator_setOrChangeUsersPasswordEmptyPassword_exceptionsShouldBeThrown() throws InvalidKeySpecException, NoSuchAlgorithmException {
@@ -113,6 +115,8 @@ public class SegueLocalAuthenticatorTest {
 	/**
 	 * Verify that setOrChangeUsersPassword works with correct input and the
 	 * result is a user object with base64 encoded passwords and a secure salt.
+	 * @throws InvalidKeySpecException
+	 * @throws NoSuchAlgorithmException
 	 */
 	@Test
 	public final void segueLocalAuthenticator_setOrChangeUsersPasswordValidPassword_passwordAndHashShouldBePopulatedAsBase64() throws InvalidKeySpecException, NoSuchAlgorithmException {
@@ -142,6 +146,8 @@ public class SegueLocalAuthenticatorTest {
 	 * @throws SegueDatabaseException
 	 * @throws NoCredentialsAvailableException
 	 * @throws NoUserException
+	 * @throws InvalidKeySpecException
+	 * @throws NoSuchAlgorithmException
 	 */
 	@Test
 	public final void segueLocalAuthenticator_authenticate_correctEmailAndIncorrectPasswordProvided()
@@ -187,7 +193,8 @@ public class SegueLocalAuthenticatorTest {
 	 * @throws SegueDatabaseException
 	 * @throws IncorrectCredentialsProvidedException
 	 * @throws NoCredentialsAvailableException
-	 * @throws NoUserException
+	 * @throws InvalidKeySpecException
+	 * @throws NoSuchAlgorithmException
 	 */
 	@Test
 	public final void segueLocalAuthenticator_authenticate_badEmailAndIncorrectPasswordProvided()
@@ -223,7 +230,8 @@ public class SegueLocalAuthenticatorTest {
 	 * @throws IncorrectCredentialsProvidedException
 	 * @throws NoCredentialsAvailableException
 	 * @throws InvalidPasswordException
-	 * @throws NoUserException
+	 * @throws InvalidKeySpecException
+	 * @throws NoSuchAlgorithmException
 	 */
 	@Test
 	public final void segueLocalAuthenticator_setPasswordAndImmediateAuthenticate_correctEmailAndPasswordProvided()

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
@@ -283,6 +283,17 @@ public class SegueLocalAuthenticatorTest {
 		}
 	}
 
+	@Test
+	public void ensureValidPassword_validSpecialCharacters() {
+		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
+				this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
+		try {
+			segueAuthenticator.ensureValidPassword("Password123 !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
+		} catch (InvalidPasswordException e) {
+			fail("We expect all of these special characters to be permitted");
+		}
+	}
+
 	@ParameterizedTest
 	@MethodSource("ensureValidPassword_invalidStrings")
 	public void ensureValidPassword_invalidStrings(String password, String expectedMessage) {

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
@@ -146,7 +146,6 @@ public class SegueLocalAuthenticatorTest {
 	@Test
 	public final void segueLocalAuthenticator_authenticate_correctEmailAndIncorrectPasswordProvided()
 			throws SegueDatabaseException, NoUserException, NoCredentialsAvailableException, InvalidKeySpecException, NoSuchAlgorithmException {
-		String someCorrectPasswordPlainText = "test5eguePassw0rd!";
 		String someCorrectPasswordHashFromDB = "q41e8iZsi0TO5xB1MWwC06jkaWx8MTnSHMp3eP/FNOTBCwpTnPX5a/KsUTUJ2cwnCiXZeATVqWEF2FCbSQp9Fg==";
 		String someCorrectSecureSaltFromDB = "P77Fhqu2/SAVGDCtu9IkHg==";
 		String usersEmailAddress = "test@test.com";
@@ -194,9 +193,6 @@ public class SegueLocalAuthenticatorTest {
 	public final void segueLocalAuthenticator_authenticate_badEmailAndIncorrectPasswordProvided()
 			throws SegueDatabaseException, IncorrectCredentialsProvidedException,
 			NoCredentialsAvailableException, InvalidKeySpecException, NoSuchAlgorithmException {
-		String someCorrectPasswordPlainText = "test5eguePassw0rd!";
-		String someCorrectPasswordHashFromDB = "q41e8iZsi0TO5xB1MWwC06jkaWx8MTnSHMp3eP/FNOTBCwpTnPX5a/KsUTUJ2cwnCiXZeATVqWEF2FCbSQp9Fg==";
-		String someCorrectSecureSaltFromDB = "P77Fhqu2/SAVGDCtu9IkHg==";
 		String usersEmailAddress = "test@test.com";
 		
 		RegisteredUser userFromDatabase = new RegisteredUser();

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 
 import static org.easymock.EasyMock.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.PASSWORD_REQUIREMENTS_ERROR_MESSAGE;
 
 /**
  * Test class for the SegueLocalAuthenticator class.
@@ -61,9 +62,6 @@ public class SegueLocalAuthenticatorTest {
             oldAlgorithm2.hashingAlgorithmName(), oldAlgorithm2,
             oldAlgorithm3.hashingAlgorithmName(), oldAlgorithm3
     );
-
-	private static final String PASSWORD_REQUIREMENTS_ERROR_MESSAGE = "Password must be at least 12 characters in length and contain at least one of each of: uppercase character, lowercase character, number and ascii punctuation character.";
-
 
 	/**
 	 * Initial configuration of tests.


### PR DESCRIPTION
https://github.com/isaaccomputerscience/isaac-cs-issues/issues/15
Increase requirements for strength of new passwords, existing passwords should not be impacted. Minimums: 1 upper case letter, 1 lower case letter, 1 digit, 1 special character, length of 8. Admins require a minimum length of 12 - as admin accounts are upgraded from standard accounts, there is no easy way to enforce separate requirements so applying this length globally is acceptable.