### PR TITLE
[17]: Improper error handling

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
@@ -112,6 +112,7 @@ public class IsaacApplicationRegister extends Application {
             this.singletons.add(injector.getInstance(PerformanceMonitor.class));
             this.singletons.add(injector.getInstance(AuditMonitor.class));
             this.singletons.add(injector.getInstance(SessionValidator.class));
+            this.singletons.add(injector.getInstance(ExceptionSanitiser.class));
 
             // initialise observers
             this.singletons.add(injector.getInstance(IGroupObserver.class));

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/SegueErrorResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/SegueErrorResponse.java
@@ -119,6 +119,10 @@ public class SegueErrorResponse implements Serializable {
         return errorMessage;
     }
 
+    public final Exception getException() {
+        return exception;
+    }
+
     public final boolean getBypassGenericSiteErrorPage() {
         return bypassGenericSiteErrorPage;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/ExceptionSanitiser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/ExceptionSanitiser.java
@@ -1,0 +1,32 @@
+package uk.ac.cam.cl.dtg.segue.api;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Provider
+public class ExceptionSanitiser implements ContainerResponseFilter {
+    private static final Logger log = LoggerFactory.getLogger(ExceptionSanitiser.class);
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) throws IOException {
+        if (containerResponseContext.getEntityType() == SegueErrorResponse.class && ((SegueErrorResponse) containerResponseContext.getEntity()).getAdditionalErrorInformation() != null) {
+            SegueErrorResponse error = (SegueErrorResponse) containerResponseContext.getEntity();
+            UUID generatedUUID = UUID.randomUUID();
+            log.error("Unsanitised exception captured. Assigned ID: " + generatedUUID + ". Exception: " + error.toString());
+            containerResponseContext.setEntity(new SegueErrorResponse(
+                    error.getResponseCode(),
+                    error.getResponseCodeType(),
+                    error.getErrorMessage() + "\nPlease report this ID if you contact support: " + generatedUUID,
+                    null
+            ));
+        }
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/ExceptionSanitiser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/ExceptionSanitiser.java
@@ -24,7 +24,7 @@ public class ExceptionSanitiser implements ContainerResponseFilter {
             containerResponseContext.setEntity(new SegueErrorResponse(
                     error.getResponseCode(),
                     error.getResponseCodeType(),
-                    error.getErrorMessage() + "\nPlease report this ID if you contact support: " + generatedUUID,
+                    error.getErrorMessage() + "\nPlease report this ID if you contact support: " + generatedUUID + ".",
                     null
             ));
         }

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/ExceptionSanitiserTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/ExceptionSanitiserTest.java
@@ -1,0 +1,65 @@
+package uk.ac.cam.cl.dtg.segue.api;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.core.Response;
+import org.easymock.Capture;
+import org.jboss.resteasy.core.interception.jaxrs.ContainerResponseContextImpl;
+import org.jboss.resteasy.core.interception.jaxrs.ResponseContainerRequestContext;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.lang3.builder.EqualsBuilder;
+import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExceptionSanitiserTest {
+
+    ExceptionSanitiser exceptionSanitiser  = new ExceptionSanitiser();
+
+    @Test
+    public void filter_sanitiseError() throws IOException {
+        SegueErrorResponse preFilterError = new SegueErrorResponse(Response.Status.BAD_REQUEST, "Test message", new Exception("Extra detail"));
+
+        Capture<SegueErrorResponse> replacementErrorCapture = newCapture();
+        ContainerRequestContext mockRequestContext = createMock(ResponseContainerRequestContext.class);
+        ContainerResponseContext mockResponseContext = createMock(ContainerResponseContextImpl.class);
+        expect(mockResponseContext.getEntityType()).andReturn(SegueErrorResponse.class).times(1);
+        expect(mockResponseContext.getEntity()).andReturn(preFilterError).times(2);
+        mockResponseContext.setEntity(capture(replacementErrorCapture));
+        expectLastCall();
+        replay(mockRequestContext, mockResponseContext);
+
+        exceptionSanitiser.filter(mockRequestContext, mockResponseContext);
+
+        String generatedUUID = replacementErrorCapture.getValue().getErrorMessage().substring(59, 95);
+        SegueErrorResponse expectedPostFilterError = new SegueErrorResponse(Response.Status.BAD_REQUEST, "Test message\nPlease report this ID if you contact support: " + generatedUUID + ".", null);
+        SegueErrorResponse actualPostFilterError = replacementErrorCapture.getValue();
+
+        verify(mockResponseContext);
+        assertEquals(expectedPostFilterError.getResponseCode(), actualPostFilterError.getResponseCode());
+        assertEquals(expectedPostFilterError.getResponseCodeType(), actualPostFilterError.getResponseCodeType());
+        assertEquals(expectedPostFilterError.getErrorMessage(), actualPostFilterError.getErrorMessage());
+        assertEquals(expectedPostFilterError.getException(), actualPostFilterError.getException());
+    }
+
+    @Test
+    public void filter_cleanError() throws IOException {
+        SegueErrorResponse preFilterError = new SegueErrorResponse(Response.Status.BAD_REQUEST, "Test message");
+
+        ContainerRequestContext mockRequestContext = createMock(ResponseContainerRequestContext.class);
+        ContainerResponseContext mockResponseContext = createMock(ContainerResponseContextImpl.class);
+        expect(mockResponseContext.getEntityType()).andReturn(SegueErrorResponse.class).times(1);
+        expect(mockResponseContext.getEntity()).andReturn(preFilterError).times(1);
+        replay(mockRequestContext, mockResponseContext);
+
+        exceptionSanitiser.filter(mockRequestContext, mockResponseContext);
+
+        verify(mockResponseContext);
+
+    }
+}


### PR DESCRIPTION
[Ticket #17](https://github.com/isaaccomputerscience/isaac-cs-issues/issues/17)
Some errors being returned to user carry too much detail, contained within the additional information field.
This change Implements an additional response filter to sanitise that additional information. The captured error is labelled with a generated uuid and written to the log. The error entity in the response is then replaced by a copy with the exception details removed and the uuid appended for reference by support if needed.