### PR TITLE
[17]: Improper error handling continuation

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/exceptionMappers/UnhandledExceptionMapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/exceptionMappers/UnhandledExceptionMapper.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
 
+import java.util.UUID;
+
 /**
  *  RESTEasy ExceptionMapper to turn unhandled exceptions into useful Response objects.
  */
@@ -36,8 +38,16 @@ public class UnhandledExceptionMapper implements ExceptionMapper<Exception> {
 
     @Override
     public Response toResponse(final Exception e) {
-        String message = String.format("%s on %s %s", e.getClass().getSimpleName(), request.getMethod(), request.getRequestURI());
-        log.error(message, e);
-        return new SegueErrorResponse(Response.Status.INTERNAL_SERVER_ERROR, "An unhandled error occurred!", e).toResponse();
+        UUID generatedUUID = UUID.randomUUID();
+        String logMessage = String.format(
+                "Unhandled exception captured. Assigned ID: %1$s. Exception at: %2$s on %3$s %4$s",
+                generatedUUID, e.getClass().getSimpleName(), request.getMethod(), request.getRequestURI()
+        );
+        String responseMessage = String.format(
+                "An unhandled error occurred!\nPlease report this ID if you contact support: %1$s.",
+                generatedUUID
+        );
+        log.error(logMessage, e);
+        return new SegueErrorResponse(Response.Status.INTERNAL_SERVER_ERROR, responseMessage, null).toResponse();
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/ExceptionSanitiser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/ExceptionSanitiser.java
@@ -20,11 +20,19 @@ public class ExceptionSanitiser implements ContainerResponseFilter {
         if (containerResponseContext.getEntityType() == SegueErrorResponse.class && ((SegueErrorResponse) containerResponseContext.getEntity()).getAdditionalErrorInformation() != null) {
             SegueErrorResponse error = (SegueErrorResponse) containerResponseContext.getEntity();
             UUID generatedUUID = UUID.randomUUID();
-            log.error("Unsanitised exception captured. Assigned ID: " + generatedUUID + ". Exception: " + error.toString());
+            String logMessage = String.format(
+                    "Unsanitised error response captured. Assigned ID: %1$s. Error content: %2$s",
+                    generatedUUID, error.toString()
+            );
+            String responseMessage = String.format(
+                    "%1$s\nPlease report this ID if you contact support: %2$s.",
+                    error.getErrorMessage(), generatedUUID
+            );
+            log.error(logMessage, error.getException());
             containerResponseContext.setEntity(new SegueErrorResponse(
                     error.getResponseCode(),
                     error.getResponseCodeType(),
-                    error.getErrorMessage() + "\nPlease report this ID if you contact support: " + generatedUUID + ".",
+                    responseMessage,
                     null
             ));
         }


### PR DESCRIPTION
[Ticket](https://github.com/isaaccomputerscience/isaac-cs-issues/issues/17)
Continuation on previous work, as testing in staging suggests that the sanitisation filter is not applied to the results of unhandled exception processing.
Sanitised response generated by UnhandledExceptionMapper, reorganised message formatting for ExceptionSanitiser for handled errors.