### PR TITLE
[77]: Replace resetPassword new password validation logic

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -698,18 +698,12 @@ public class UserAuthenticationManager {
      */
     public RegisteredUser resetPassword(final String token, final String newPassword)
             throws InvalidTokenException, InvalidPasswordException, SegueDatabaseException, InvalidKeySpecException, NoSuchAlgorithmException {
-        // Ensure new password is valid
-
-        if (null == newPassword || newPassword.isEmpty()) {
-            throw new InvalidPasswordException("Empty passwords are not allowed if using local authentication.");
-        }
-
-        if (newPassword.length() < 6) {
-            throw new InvalidPasswordException("Password must be at least 6 characters in length.");
-        }
 
         IPasswordAuthenticator authenticator = (IPasswordAuthenticator) this.registeredAuthProviders
                 .get(AuthenticationProvider.SEGUE);
+
+        // Ensure new password is valid
+        authenticator.ensureValidPassword(newPassword);
 
         // Ensure reset token is valid
         RegisteredUser user = authenticator.getRegisteredUserByToken(token);


### PR DESCRIPTION
[Ticket](https://github.com/isaaccomputerscience/isaac-cs-issues/issues/77)
Update the resetPassword method in the UserAuthenticationManager to make use of the invoked authenticator's password validation function instead of using outdated independent validation logic.