### PR TITLE
Robert/121 email update session token relocation

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/RegisteredUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/RegisteredUser.java
@@ -47,8 +47,6 @@ public class RegisteredUser extends AbstractSegueUser {
   private Date lastUpdated;
   private Date lastSeen;
 
-  private Integer sessionToken;
-
   /**
    * Full constructor for the User object.
    *
@@ -389,24 +387,6 @@ public class RegisteredUser extends AbstractSegueUser {
    */
   public void setLastSeen(final Date lastSeen) {
     this.lastSeen = lastSeen;
-  }
-
-  /**
-   * Gets the sessionToken.
-   *
-   * @return the sessionToken
-   */
-  public Integer getSessionToken() {
-    return sessionToken;
-  }
-
-  /**
-   * Sets the sessionToken.
-   *
-   * @param sessionToken the sessionToken to set
-   */
-  public void setSessionToken(final Integer sessionToken) {
-    this.sessionToken = sessionToken;
   }
 
   /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -453,17 +453,15 @@ public class UserAuthenticationManager {
     }
     // Retrieve the user from database.
     try {
-      // Get the user the cookie claims to belong to from the session information:
-      long currentUserId = Long.parseLong(currentSessionInformation.get(SESSION_USER_ID));
-      RegisteredUser userToReturn = database.getById(currentUserId);
-
       // Check that the user's session is indeed valid:
-      if (null == userToReturn || !this.isValidUsersSession(currentSessionInformation, userToReturn)) {
+      if (!isSessionValid(currentSessionInformation)) {
         log.debug("User session has failed validation. Treating as logged out. Session: " + currentSessionInformation);
         return null;
       }
 
-      return userToReturn;
+      // Get the user the cookie claims to belong to from the session information:
+      long currentUserId = Long.parseLong(currentSessionInformation.get(SESSION_USER_ID));
+      return database.getById(currentUserId);
     } catch (SegueDatabaseException e) {
       log.error("Internal Database error. Failed to resolve current user.", e);
       return null;
@@ -920,14 +918,14 @@ public class UserAuthenticationManager {
    * Verifies the HMAC for userId, expiry date, session token and partial login status; but DOES NOT enforce
    * partial login as invalid! I.e. this method will return true for partial logins.
    *
-   * @param sessionInformation - map containing session information retrieved from the cookie.
-   * @param userFromDatabase   - the real user we are to validate this cookie against.
+   * @param sessionInformation map containing session information retrieved from the cookie
+   * @param sessionTokenFromDatabase the real session token to validate this cookie against
    * @return true if it is still valid, false if not.
    */
   private boolean isValidUsersSession(final Map<String, String> sessionInformation,
-                                      final RegisteredUser userFromDatabase) {
+                                      final Integer sessionTokenFromDatabase) {
     Validate.notNull(sessionInformation);
-    Validate.notNull(userFromDatabase);
+    Validate.notNull(sessionTokenFromDatabase);
 
     SimpleDateFormat sessionDateFormat = new SimpleDateFormat(DEFAULT_DATE_FORMAT);
 
@@ -964,8 +962,8 @@ public class UserAuthenticationManager {
     }
 
     // Check that the session token is still valid:
-    if (userFromDatabase.getSessionToken() == NO_SESSION_TOKEN_RESERVED_VALUE
-        || !userFromDatabase.getSessionToken().toString().equals(userSessionToken)) {
+    if (sessionTokenFromDatabase == NO_SESSION_TOKEN_RESERVED_VALUE
+        || !sessionTokenFromDatabase.toString().equals(userSessionToken)) {
       log.debug("Invalid session token detected for user id " + userId);
       return false;
     }
@@ -1145,8 +1143,8 @@ public class UserAuthenticationManager {
   public boolean isSessionValid(final Map<String, String> currentSessionInformation) {
     try {
       long currentUserId = Long.parseLong(currentSessionInformation.get(SESSION_USER_ID));
-      RegisteredUser userToReturn = database.getById(currentUserId);
-      if (null == userToReturn || !this.isValidUsersSession(currentSessionInformation, userToReturn)) {
+      Integer databaseSessionToken = database.getSessionToken(currentUserId);
+      if (null == databaseSessionToken || !this.isValidUsersSession(currentSessionInformation, databaseSessionToken)) {
         log.warn("User session has failed validation. Validation checks did not pass.");
         return false;
       }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserDataManager.java
@@ -142,7 +142,7 @@ public interface IUserDataManager {
 
   /**
    * This function will also include tombstoned results back to the caller.
-   * WARNING- Do not expect complete RegisteredUser Objects as data may be missing.
+   * WARNING - Do not expect complete RegisteredUser Objects as data may be missing.
    *
    * @param id                  user id.
    * @param includeDeletedUsers true will allow inclusion of tombstoned users false will filter them out.
@@ -231,28 +231,46 @@ public interface IUserDataManager {
   void updateUserLastSeen(RegisteredUser user, Date date) throws SegueDatabaseException;
 
   /**
+   * Create a session token record for a user object in the data store with a randomly generated value.
+   *
+   * @param user the user object to create the session token for
+   * @return the value of the newly generated session token
+   * @throws SegueDatabaseException If there is an internal database error
+   */
+  Integer createSessionToken(RegisteredUser user) throws SegueDatabaseException;
+
+  /**
+   * Create a session token record for a user object in the data store with a specified value.
+   *
+   * @param user          the user object to create the session token for
+   * @param newTokenValue the new value to set as the session token
+   * @throws SegueDatabaseException - If there is an internal database error
+   */
+  void createSessionToken(RegisteredUser user, Integer newTokenValue) throws SegueDatabaseException;
+
+  /**
    * Update the session token of a user object in the data store to a randomly generated value.
    *
-   * @param user - the user object to update the session token of.
+   * @param user the user object to update the session token of
    * @return the value of the newly generated session token
-   * @throws SegueDatabaseException - If there is an internal database error.
+   * @throws SegueDatabaseException If there is an internal database error
    */
   Integer regenerateSessionToken(RegisteredUser user) throws SegueDatabaseException;
 
   /**
    * Update the session token of a user object in the data store to null.
    *
-   * @param user - the user object to update the session token of.
-   * @throws SegueDatabaseException - If there is an internal database error.
+   * @param user the user object to update the session token of
+   * @throws SegueDatabaseException If there is an internal database error
    */
   void invalidateSessionToken(RegisteredUser user) throws SegueDatabaseException;
 
   /**
    * Update the session token of a user object in the data store to a specified value.
    *
-   * @param user          - the user object to update the session token of.
-   * @param newTokenValue - the new value to set as the session token
-   * @throws SegueDatabaseException - If there is an internal database error.
+   * @param user          the user object to update the session token of
+   * @param newTokenValue the new value to set as the session token
+   * @throws SegueDatabaseException If there is an internal database error
    */
   void updateSessionToken(RegisteredUser user, Integer newTokenValue) throws SegueDatabaseException;
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserDataManager.java
@@ -244,7 +244,7 @@ public interface IUserDataManager {
    *
    * @param user          the user object to create the session token for
    * @param newTokenValue the new value to set as the session token
-   * @throws SegueDatabaseException - If there is an internal database error
+   * @throws SegueDatabaseException if there is an internal database error
    */
   void createSessionToken(RegisteredUser user, Integer newTokenValue) throws SegueDatabaseException;
 
@@ -253,7 +253,7 @@ public interface IUserDataManager {
    *
    * @param user the user object to update the session token of
    * @return the value of the newly generated session token
-   * @throws SegueDatabaseException If there is an internal database error
+   * @throws SegueDatabaseException if there is an internal database error
    */
   Integer regenerateSessionToken(RegisteredUser user) throws SegueDatabaseException;
 
@@ -261,7 +261,7 @@ public interface IUserDataManager {
    * Update the session token of a user object in the data store to null.
    *
    * @param user the user object to update the session token of
-   * @throws SegueDatabaseException If there is an internal database error
+   * @throws SegueDatabaseException if there is an internal database error
    */
   void invalidateSessionToken(RegisteredUser user) throws SegueDatabaseException;
 
@@ -270,9 +270,18 @@ public interface IUserDataManager {
    *
    * @param user          the user object to update the session token of
    * @param newTokenValue the new value to set as the session token
-   * @throws SegueDatabaseException If there is an internal database error
+   * @throws SegueDatabaseException if there is an internal database error
    */
   void updateSessionToken(RegisteredUser user, Integer newTokenValue) throws SegueDatabaseException;
+
+  /**
+   * Retrieve the currently valid session token stored in the database for the specified user id.
+   *
+   * @param userId the userId to retrieve the session token for
+   * @return the Integer sessionToken if found or null if not
+   * @throws SegueDatabaseException if there is an internal database error
+   */
+  Integer getSessionToken(Long userId) throws  SegueDatabaseException;
 
   /**
    * Count all the users by role and return a map.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -683,9 +683,9 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
 
   @Override
   public Integer regenerateSessionToken(final RegisteredUser user) throws SegueDatabaseException {
-    Integer newSessionToken = generateRandomTokenInteger();
-    this.updateSessionToken(user, newSessionToken);
-    return newSessionToken;
+    Integer newSessionTokenValue = generateRandomTokenInteger();
+    this.updateSessionToken(user, newSessionTokenValue);
+    return newSessionTokenValue;
   }
 
   private static Integer generateRandomTokenInteger() {
@@ -700,20 +700,45 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
   }
 
   @Override
+  public Integer createSessionToken(final RegisteredUser user) throws SegueDatabaseException {
+    Integer sessionTokenValue = generateRandomTokenInteger();
+    this.createSessionToken(user, sessionTokenValue);
+    return sessionTokenValue;
+  }
+
+  @Override
+  public void createSessionToken(final RegisteredUser user, final Integer sessionTokenValue)
+      throws SegueDatabaseException {
+    Validate.notNull(user);
+
+    String query = "INSERT INTO user_session_token(user_id, session_token) VALUES (?, ?);";
+    try (Connection conn = database.getDatabaseConnection();
+         PreparedStatement pst = conn.prepareStatement(query)
+    ) {
+      pst.setLong(FIELD_CREATE_SESSION_TOKEN_USER_ID, user.getId());
+      pst.setInt(FIELD_CREATE_SESSION_TOKEN_VALUE, sessionTokenValue);
+      pst.execute();
+    } catch (SQLException e) {
+      throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
+    }
+  }
+
+  @Override
   public void invalidateSessionToken(final RegisteredUser user) throws SegueDatabaseException {
     // -1 is reserved for 'no assigned token', used for when a user is logged out for example
     this.updateSessionToken(user, NO_SESSION_TOKEN_RESERVED_VALUE);
   }
 
   @Override
-  public void updateSessionToken(final RegisteredUser user, final Integer newTokenValue) throws SegueDatabaseException {
+  public void updateSessionToken(final RegisteredUser user, final Integer newSessionTokenValue)
+      throws SegueDatabaseException {
     Validate.notNull(user);
 
-    String query = "UPDATE users SET session_token = ? WHERE id = ?";
+    String query = "UPDATE user_session_token SET session_token = ? WHERE user_id = ?";
     try (Connection conn = database.getDatabaseConnection();
          PreparedStatement pst = conn.prepareStatement(query)
     ) {
-      pst.setInt(FIELD_UPDATE_SESSION_TOKEN_NEW_VALUE, newTokenValue);
+      pst.setInt(FIELD_UPDATE_SESSION_TOKEN_NEW_VALUE, newSessionTokenValue);
       pst.setLong(FIELD_UPDATE_SESSION_TOKEN_USER_ID, user.getId());
       pst.execute();
     } catch (SQLException e) {
@@ -739,14 +764,11 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
       userToCreate.setEmailVerificationStatus(EmailVerificationStatus.NOT_VERIFIED);
     }
 
-    Integer newSessionToken = generateRandomTokenInteger();
-    userToCreate.setSessionToken(newSessionToken);
-
     String query = "INSERT INTO users(family_name, given_name, email, role, date_of_birth, gender,"
         + " registration_date, school_id, school_other, last_updated, email_verification_status, last_seen,"
-        + " email_verification_token, email_to_verify, teacher_pending, session_token, registered_contexts,"
+        + " email_verification_token, email_to_verify, teacher_pending, registered_contexts,"
         + " registered_contexts_last_confirmed)"
-        + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
+        + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
     try (Connection conn = database.getDatabaseConnection();
          PreparedStatement pst = conn.prepareStatement(query, Statement.RETURN_GENERATED_KEYS)
     ) {
@@ -775,9 +797,8 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
       setValueHelper(pst, FIELD_CREATE_UPDATE_USER_EMAIL_VERIFICATION_TOKEN, userToCreate.getEmailVerificationToken());
       setValueHelper(pst, FIELD_CREATE_UPDATE_USER_EMAIL_TO_VERIFY, userToCreate.getEmailToVerify());
       setValueHelper(pst, FIELD_CREATE_UPDATE_USER_TEACHER_PENDING, userToCreate.getTeacherPending());
-      setValueHelper(pst, FIELD_CREATE_USER_SESSION_TOKEN, userToCreate.getSessionToken());
-      pst.setArray(FIELD_CREATE_USER_REGISTERED_CONTEXTS, userContexts);
-      setValueHelper(pst, FIELD_CREATE_USER_REGISTERED_CONTEXTS_LAST_CONFIRMED,
+      pst.setArray(FIELD_CREATE_UPDATE_USER_REGISTERED_CONTEXTS, userContexts);
+      setValueHelper(pst, FIELD_CREATE_UPDATE_USER_REGISTERED_CONTEXTS_LAST_CONFIRMED,
           userToCreate.getRegisteredContextsLastConfirmed());
 
       if (pst.executeUpdate() == 0) {
@@ -867,8 +888,9 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
           userContextsJsonb.add(jsonMapper.writeValueAsString(registeredContext));
         }
       }
-      pst.setArray(FIELD_UPDATE_USER_REGISTERED_CONTEXTS, conn.createArrayOf("jsonb", userContextsJsonb.toArray()));
-      setValueHelper(pst, FIELD_UPDATE_USER_REGISTERED_CONTEXTS_LAST_CONFIRMED,
+      pst.setArray(FIELD_CREATE_UPDATE_USER_REGISTERED_CONTEXTS, conn.createArrayOf(
+          "jsonb", userContextsJsonb.toArray()));
+      setValueHelper(pst, FIELD_CREATE_UPDATE_USER_REGISTERED_CONTEXTS_LAST_CONFIRMED,
           userToCreate.getRegisteredContextsLastConfirmed());
 
       setValueHelper(pst, FIELD_UPDATE_USER_USER_ID, userToCreate.getId());
@@ -1067,6 +1089,10 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
   private static final int FIELD_UPDATE_LAST_SEEN_LAST_SEEN = 1;
   private static final int FIELD_UPDATE_LAST_SEEN_USER_ID = 2;
 
+  // createSessionToken
+  private static final int FIELD_CREATE_SESSION_TOKEN_USER_ID = 1;
+  private static final int FIELD_CREATE_SESSION_TOKEN_VALUE = 2;
+
   // updateSessionToken
   private static final int FIELD_UPDATE_SESSION_TOKEN_NEW_VALUE = 1;
   private static final int FIELD_UPDATE_SESSION_TOKEN_USER_ID = 2;
@@ -1087,10 +1113,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
   private static final int FIELD_CREATE_UPDATE_USER_EMAIL_VERIFICATION_TOKEN = 13;
   private static final int FIELD_CREATE_UPDATE_USER_EMAIL_TO_VERIFY = 14;
   private static final int FIELD_CREATE_UPDATE_USER_TEACHER_PENDING = 15;
-  private static final int FIELD_CREATE_USER_SESSION_TOKEN = 16;
-  private static final int FIELD_CREATE_USER_REGISTERED_CONTEXTS = 17;
-  private static final int FIELD_CREATE_USER_REGISTERED_CONTEXTS_LAST_CONFIRMED = 18;
-  private static final int FIELD_UPDATE_USER_REGISTERED_CONTEXTS = 16;
-  private static final int FIELD_UPDATE_USER_REGISTERED_CONTEXTS_LAST_CONFIRMED = 17;
+  private static final int FIELD_CREATE_UPDATE_USER_REGISTERED_CONTEXTS = 16;
+  private static final int FIELD_CREATE_UPDATE_USER_REGISTERED_CONTEXTS_LAST_CONFIRMED = 17;
   private static final int FIELD_UPDATE_USER_USER_ID = 18;
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -47,7 +47,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.Validate;
-import org.jetbrains.annotations.Nullable;
 import uk.ac.cam.cl.dtg.isaac.dos.users.EmailVerificationStatus;
 import uk.ac.cam.cl.dtg.isaac.dos.users.Gender;
 import uk.ac.cam.cl.dtg.isaac.dos.users.RegisteredUser;
@@ -771,7 +770,6 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
    * @throws SQLException           if there is an internal database error
    * @throws SegueDatabaseException if more than one result is returned
    */
-  @Nullable
   private static Integer findOneToken(ResultSet results) throws SQLException, SegueDatabaseException {
     // are there any results
     if (!results.isBeforeFirst()) {

--- a/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
+++ b/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
@@ -652,6 +652,17 @@ CREATE TABLE public.user_preferences (
 ALTER TABLE public.user_preferences OWNER TO rutherford;
 
 --
+-- Name: user_session_token; Type: TABLE; Schema: public; Owner: rutherford
+--
+
+CREATE TABLE public.user_session_token (
+    user_id integer NOT NULL,
+    session_token integer DEFAULT 0 NOT NULL
+);
+
+ALTER TABLE public.user_session_token OWNER TO rutherford;
+
+--
 -- Name: user_streak_freezes; Type: TABLE; Schema: public; Owner: rutherford
 --
 
@@ -717,7 +728,6 @@ CREATE TABLE public.users (
     last_seen timestamp without time zone,
     email_to_verify text,
     email_verification_token text,
-    session_token integer DEFAULT 0 NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     teacher_pending boolean DEFAULT false
 );
@@ -1057,6 +1067,14 @@ ALTER TABLE ONLY public.user_preferences
 
 
 --
+-- Name: user_session_token user_id_pk; Type: CONSTRAINT; Schema: public; Owner: rutherford
+--
+
+ALTER TABLE ONLY public.user_session_token
+    ADD CONSTRAINT user_id_pk PRIMARY KEY (user_id);
+
+
+--
 -- Name: user_streak_freezes user_streak_freeze_pkey; Type: CONSTRAINT; Schema: public; Owner: rutherford
 --
 
@@ -1252,6 +1270,13 @@ CREATE INDEX user_credentials_reset_tokens ON public.user_credentials USING btre
 --
 
 CREATE UNIQUE INDEX user_email ON public.users USING btree (email);
+
+
+--
+-- Name: user_session_token_by_user_id; Type: INDEX; Schema: public; Owner: rutherford
+--
+
+CREATE INDEX user_session_token_by_user_id ON public.user_session_token USING btree (user_id);
 
 
 --
@@ -1489,6 +1514,14 @@ ALTER TABLE ONLY public.user_preferences
 
 ALTER TABLE ONLY public.user_associations
     ADD CONSTRAINT user_receiving_permissions_key FOREIGN KEY (user_id_receiving_permission) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: user_session_token user_session_token_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: rutherford
+--
+
+ALTER TABLE ONLY public.user_session_token
+    ADD CONSTRAINT user_session_token_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
 
 --

--- a/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
+++ b/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
@@ -660,6 +660,7 @@ CREATE TABLE public.user_session_token (
     session_token integer DEFAULT 0 NOT NULL
 );
 
+
 ALTER TABLE public.user_session_token OWNER TO rutherford;
 
 --

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManagerTest.java
@@ -93,11 +93,7 @@ public class UserAuthenticationManagerTest {
     expect(mockRequest.getCookies()).andReturn(new Cookie[] {segueAuthCookie}).anyTimes();
     replay(mockRequest);
 
-    RegisteredUser mockUser = createNiceMock(RegisteredUser.class);
-    expect(mockUser.getSessionToken()).andReturn(1).times(2);
-    replay(mockUser);
-
-    expect(dummyDatabase.getById(1L)).andReturn(mockUser);
+    expect(dummyDatabase.getSessionToken(1L)).andReturn(1).times(2);
     replay(dummyDatabase);
 
     assertTrue(userAuthenticationManager.isSessionValid(mockRequest));
@@ -109,11 +105,7 @@ public class UserAuthenticationManagerTest {
     expect(mockRequest.getCookies()).andReturn(null).anyTimes();
     replay(mockRequest);
 
-    RegisteredUser mockUser = createNiceMock(RegisteredUser.class);
-    expect(mockUser.getSessionToken()).andReturn(1);
-    replay(mockUser);
-
-    expect(dummyDatabase.getById(1L)).andReturn(mockUser);
+    expect(dummyDatabase.getSessionToken(1L)).andReturn(1);
     replay(dummyDatabase);
 
     assertFalse(userAuthenticationManager.isSessionValid(mockRequest));
@@ -126,11 +118,7 @@ public class UserAuthenticationManagerTest {
     expect(mockRequest.getCookies()).andReturn(new Cookie[] {notAuthCookie}).anyTimes();
     replay(mockRequest);
 
-    RegisteredUser mockUser = createNiceMock(RegisteredUser.class);
-    expect(mockUser.getSessionToken()).andReturn(1);
-    replay(mockUser);
-
-    expect(dummyDatabase.getById(1L)).andReturn(mockUser);
+    expect(dummyDatabase.getSessionToken(1L)).andReturn(1);
     replay(dummyDatabase);
 
     assertFalse(userAuthenticationManager.isSessionValid(mockRequest));
@@ -168,10 +156,10 @@ public class UserAuthenticationManagerTest {
   @Test
   public void destroyUserSession() throws JsonProcessingException, SegueDatabaseException, NoUserLoggedInException {
     RegisteredUser mockUser = createNiceMock(RegisteredUser.class);
-    expect(mockUser.getSessionToken()).andReturn(1).times(2);
     replay(mockUser);
 
     expect(dummyDatabase.getById(1L)).andReturn(mockUser);
+    expect(dummyDatabase.getSessionToken(1L)).andReturn(1);
     dummyDatabase.invalidateSessionToken(mockUser);
     expectLastCall();
     replay(dummyDatabase);

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
@@ -190,7 +190,7 @@ public class UserManagerTest {
     Calendar calendar = Calendar.getInstance();
     calendar.add(Calendar.SECOND, 500);
     String validDateString = sdf.format(calendar.getTime());
-    Integer sessionToken = 7;
+    int sessionToken = 7;
 
     RegisteredUser returnUser = new RegisteredUser(validUserId, "TestFirstName", "TestLastName", "", Role.STUDENT,
         new Date(), Gender.MALE, new Date(), null, null, null, null, false);
@@ -581,14 +581,14 @@ public class UserManagerTest {
     Calendar calendar = Calendar.getInstance();
     calendar.add(Calendar.SECOND, 500);
     String validDateString = sdf.format(calendar.getTime());
-    Integer sessionToken = 7;
+    int sessionToken = 7;
 
     Map<String, String> validSessionInformation = getSessionInformationAsAMap(authManager, validUserId,
         validDateString, sessionToken);
 
     Map<String, String> tamperedSessionInformation = ImmutableMap.of(
         Constants.SESSION_USER_ID, validUserId,
-        Constants.SESSION_TOKEN, sessionToken.toString(),
+        Constants.SESSION_TOKEN, String.valueOf(sessionToken),
         Constants.DATE_EXPIRES, validDateString + "1",
         Constants.HMAC, validSessionInformation.get(Constants.HMAC)
     );
@@ -638,7 +638,7 @@ public class UserManagerTest {
 
     // Assert
     verify(dummyQuestionDatabase, dummySession, request);
-    assertTrue(!valid);
+    assertFalse(valid);
   }
 
   /**
@@ -655,8 +655,8 @@ public class UserManagerTest {
     HttpServletRequest request = createMock(HttpServletRequest.class);
 
     String validUserId = "123";
-    Integer correctSessionToken = 7;
-    Integer incorrectSessionToken = 0;
+    int correctSessionToken = 7;
+    int incorrectSessionToken = 0;
     Calendar calendar = Calendar.getInstance();
     calendar.add(Calendar.SECOND, 500);
     String validDateString = sdf.format(calendar.getTime());
@@ -675,7 +675,7 @@ public class UserManagerTest {
 
     // Assert
     verify(dummyQuestionDatabase, dummySession, request);
-    assertTrue(!valid);
+    assertFalse(valid);
   }
 
   /**
@@ -684,11 +684,10 @@ public class UserManagerTest {
   @Test
   public final void isUserNameValid_longNameProvided_returnsFalse() {
     // Arrange
-    UserAccountManager userManager = buildTestUserManager();
     String name = StringUtils.repeat("a", 256);
 
     // Act
-    boolean valid = userManager.isUserNameValid(name);
+    boolean valid = UserAccountManager.isUserNameValid(name);
 
     // Assert
     assertFalse(valid);
@@ -700,11 +699,10 @@ public class UserManagerTest {
   @Test
   public final void isUserNameValid_acceptableNameProvided_returnsTrue() {
     // Arrange
-    UserAccountManager userManager = buildTestUserManager();
     String name = StringUtils.repeat("a", 255);
 
     // Act
-    boolean valid = userManager.isUserNameValid(name);
+    boolean valid = UserAccountManager.isUserNameValid(name);
 
     // Assert
     assertTrue(valid);
@@ -716,11 +714,10 @@ public class UserManagerTest {
   @Test
   public final void isUserNameValid_nameWithIllegalCharactersProvided_returnsFalse() {
     // Arrange
-    UserAccountManager userManager = buildTestUserManager();
     String name = "Matthew*";
 
     // Act
-    boolean valid = userManager.isUserNameValid(name);
+    boolean valid = UserAccountManager.isUserNameValid(name);
 
     // Assert
     assertFalse(valid);
@@ -732,11 +729,10 @@ public class UserManagerTest {
   @Test
   public final void isUserNameValid_emptyNameProvided_returnsFalse() {
     // Arrange
-    UserAccountManager userManager = buildTestUserManager();
     String name = "";
 
     // Act
-    boolean valid = userManager.isUserNameValid(name);
+    boolean valid = UserAccountManager.isUserNameValid(name);
 
     // Assert
     assertFalse(valid);
@@ -752,7 +748,7 @@ public class UserManagerTest {
     String name = null;
 
     // Act
-    boolean valid = userManager.isUserNameValid(name);
+    boolean valid = UserAccountManager.isUserNameValid(name);
 
     // Assert
     assertFalse(valid);

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
@@ -547,7 +547,7 @@ public class UserManagerTest {
     Calendar calendar = Calendar.getInstance();
     calendar.add(Calendar.SECOND, 500);
     String validDateString = sdf.format(calendar.getTime());
-    Integer sessionToken = 7;
+    int sessionToken = 7;
 
     Map<String, String> sessionInformation =
         getSessionInformationAsAMap(authManager, validUserId, validDateString, sessionToken);
@@ -623,7 +623,7 @@ public class UserManagerTest {
     Calendar calendar = Calendar.getInstance();
     calendar.add(Calendar.SECOND, -60); // Expired 60 seconds ago
     String expiredDateString = sdf.format(calendar.getTime());
-    Integer sessionToken = 7;
+    int sessionToken = 7;
 
     Map<String, String> validSessionInformation = getSessionInformationAsAMap(authManager, validUserId,
         expiredDateString, sessionToken);

--- a/src/test/resources/test-postgres-rutherford-data-dump.sql
+++ b/src/test/resources/test-postgres-rutherford-data-dump.sql
@@ -20,19 +20,19 @@ SET row_security = off;
 -- Data for Name: users; Type: TABLE DATA; Schema: public; Owner: rutherford
 --
 
-COPY public.users (id, _id, family_name, given_name, email, role, date_of_birth, gender, registration_date, school_id, school_other, registered_contexts, registered_contexts_last_confirmed, last_updated, email_verification_status, last_seen, email_to_verify, email_verification_token, session_token, deleted, teacher_pending) FROM stdin;
-2	\N	Test	Test Admin	test-admin@test.com	ADMIN	\N	OTHER	2019-08-01 12:40:16.738	\N	A Manually Entered School	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"all\\"}"}	2022-07-06 10:48:59.527	2022-07-06 10:48:59.673	VERIFIED	2022-08-03 12:07:08.761	test-admin@test.com	AwrblcwVoRFMWxJtV2TXAalOeA7a84TpD3rO2RmE	0	f	f
-11	\N	Student	Erika	erika-student@test.com	STUDENT	\N	FEMALE	2022-07-03 17:34:07		A Manually Entered School	{}	\N	2022-07-05 17:34:31	VERIFIED	2022-08-09 10:53:44.547	erika-student@test.com	\N	0	f	f
-9	\N	Student	Charlie	charlie-student@test.com	STUDENT	\N	MALE	2022-07-05 17:34:07	130615	\N	{}	\N	2022-07-05 17:34:31	VERIFIED	2022-08-09 10:54:15.741	charlie-student@test.com	\N	0	f	f
-4	\N	Editor	Test Editor	test-editor@test.com	CONTENT_EDITOR	\N	PREFER_NOT_TO_SAY	2019-08-01 12:50:32.631	133801	\N	{}	\N	2021-03-09 16:46:26.28	VERIFIED	2022-08-09 10:54:30.095	test-editor@test.com	nAAK4xSBuAPRejM4YPNfTKRDGK4Oa1VuL3EMmJburjE	0	f	f
-3	\N	Event Manager	Test Event	test-event@test.com	EVENT_MANAGER	\N	OTHER	2019-08-01 12:43:14.583	133801	\N	{}	\N	2021-03-09 16:47:03.77	VERIFIED	2022-08-09 10:54:42.013	test-event@test.com	QlIS3PVS33I8jmMo3JPQgIn2xaKe4gFgwXfH4qiI8	0	f	f
-1	\N	Progress	Test Progress	test-progress@test.com	STUDENT	\N	FEMALE	2019-08-01 12:28:22.869	130615	\N	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"ocr\\"}"}	2021-10-04 14:10:37.441	2021-11-05 10:52:13.018	VERIFIED	2022-08-09 10:54:55.362	test-progress@test.com	scIF1UJeYyGRGwGrwGNUyIWuZxKBrQHd8evcAeZk	0	f	f
-6	\N	Student	Test Student	test-student@test.com	STUDENT	\N	MALE	2019-08-01 12:51:39.981	110158	\N	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"ocr\\"}"}	2021-10-04 14:12:13.351	2021-10-04 14:12:13.384	VERIFIED	2022-08-09 10:55:06.592	test-student@test.com	ZMUU7NbjhUSawOClEzb1KPEMcUA93QCkxuGejMwmE	0	f	f
-10	\N	Teacher	Dave	dave-teacher@test.com	TEACHER	\N	MALE	2022-07-06 15:15:00	110158	\N	{}	\N	\N	VERIFIED	2022-08-09 10:55:35.591	dave-teacher@test.com	\N	0	f	f
-7	\N	Student	Alice	alice-student@test.com	STUDENT	1991-01-01	FEMALE	2022-07-05 17:31:12	\N	A Manually Entered School	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"all\\"}"}	2022-07-06 10:52:35.922	2022-07-06 10:52:36.056	VERIFIED	2022-08-09 10:56:00.055	alice-student@test.com	\N	0	f	f
-8	\N	Student	Bob	bob-student@test.com	STUDENT	\N	MALE	2022-07-05 17:32:41	110158	\N	{}	\N	2022-07-05 17:32:57	VERIFIED	2022-08-09 10:56:12.965	bob-student@test.com	\N	0	f	f
-5	\N	Teacher	Test Teacher	test-teacher@test.com	TEACHER	\N	FEMALE	2019-08-01 12:51:05.416	\N	A Manually Entered School	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"all\\"}"}	2022-08-03 12:08:57.662	2022-08-03 12:08:57.741	VERIFIED	2022-08-17 10:54:22.763	test-teacher@test.com	m9A8P0VbpFQnzOdXOywx75lpaWSpssLmQ779ij2b5LQ	0	f	f
-12	\N	Tutor	Test Tutor	test-tutor@test.com	TUTOR	\N	\N	2022-12-12 14:42:02.974	\N	\N	{}	\N	2022-12-12 14:42:02.974	NOT_VERIFIED	2022-12-12 14:48:40.236	test-tutor@test.com	4V115j6oH0YctCgBYXclb3WUT8D2Bz4nIaoJCasCJs	0	f	f
+COPY public.users (id, _id, family_name, given_name, email, role, date_of_birth, gender, registration_date, school_id, school_other, registered_contexts, registered_contexts_last_confirmed, last_updated, email_verification_status, last_seen, email_to_verify, email_verification_token, deleted, teacher_pending) FROM stdin;
+2	\N	Test	Test Admin	test-admin@test.com	ADMIN	\N	OTHER	2019-08-01 12:40:16.738	\N	A Manually Entered School	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"all\\"}"}	2022-07-06 10:48:59.527	2022-07-06 10:48:59.673	VERIFIED	2022-08-03 12:07:08.761	test-admin@test.com	AwrblcwVoRFMWxJtV2TXAalOeA7a84TpD3rO2RmE	f	f
+11	\N	Student	Erika	erika-student@test.com	STUDENT	\N	FEMALE	2022-07-03 17:34:07		A Manually Entered School	{}	\N	2022-07-05 17:34:31	VERIFIED	2022-08-09 10:53:44.547	erika-student@test.com	\N	f	f
+9	\N	Student	Charlie	charlie-student@test.com	STUDENT	\N	MALE	2022-07-05 17:34:07	130615	\N	{}	\N	2022-07-05 17:34:31	VERIFIED	2022-08-09 10:54:15.741	charlie-student@test.com	\N	f	f
+4	\N	Editor	Test Editor	test-editor@test.com	CONTENT_EDITOR	\N	PREFER_NOT_TO_SAY	2019-08-01 12:50:32.631	133801	\N	{}	\N	2021-03-09 16:46:26.28	VERIFIED	2022-08-09 10:54:30.095	test-editor@test.com	nAAK4xSBuAPRejM4YPNfTKRDGK4Oa1VuL3EMmJburjE	f	f
+3	\N	Event Manager	Test Event	test-event@test.com	EVENT_MANAGER	\N	OTHER	2019-08-01 12:43:14.583	133801	\N	{}	\N	2021-03-09 16:47:03.77	VERIFIED	2022-08-09 10:54:42.013	test-event@test.com	QlIS3PVS33I8jmMo3JPQgIn2xaKe4gFgwXfH4qiI8	f	f
+1	\N	Progress	Test Progress	test-progress@test.com	STUDENT	\N	FEMALE	2019-08-01 12:28:22.869	130615	\N	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"ocr\\"}"}	2021-10-04 14:10:37.441	2021-11-05 10:52:13.018	VERIFIED	2022-08-09 10:54:55.362	test-progress@test.com	scIF1UJeYyGRGwGrwGNUyIWuZxKBrQHd8evcAeZk	f	f
+6	\N	Student	Test Student	test-student@test.com	STUDENT	\N	MALE	2019-08-01 12:51:39.981	110158	\N	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"ocr\\"}"}	2021-10-04 14:12:13.351	2021-10-04 14:12:13.384	VERIFIED	2022-08-09 10:55:06.592	test-student@test.com	ZMUU7NbjhUSawOClEzb1KPEMcUA93QCkxuGejMwmE	f	f
+10	\N	Teacher	Dave	dave-teacher@test.com	TEACHER	\N	MALE	2022-07-06 15:15:00	110158	\N	{}	\N	\N	VERIFIED	2022-08-09 10:55:35.591	dave-teacher@test.com	\N	f	f
+7	\N	Student	Alice	alice-student@test.com	STUDENT	1991-01-01	FEMALE	2022-07-05 17:31:12	\N	A Manually Entered School	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"all\\"}"}	2022-07-06 10:52:35.922	2022-07-06 10:52:36.056	VERIFIED	2022-08-09 10:56:00.055	alice-student@test.com	\N	f	f
+8	\N	Student	Bob	bob-student@test.com	STUDENT	\N	MALE	2022-07-05 17:32:41	110158	\N	{}	\N	2022-07-05 17:32:57	VERIFIED	2022-08-09 10:56:12.965	bob-student@test.com	\N	f	f
+5	\N	Teacher	Test Teacher	test-teacher@test.com	TEACHER	\N	FEMALE	2019-08-01 12:51:05.416	\N	A Manually Entered School	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"all\\"}"}	2022-08-03 12:08:57.662	2022-08-03 12:08:57.741	VERIFIED	2022-08-17 10:54:22.763	test-teacher@test.com	m9A8P0VbpFQnzOdXOywx75lpaWSpssLmQ779ij2b5LQ	f	f
+12	\N	Tutor	Test Tutor	test-tutor@test.com	TUTOR	\N	\N	2022-12-12 14:42:02.974	\N	\N	{}	\N	2022-12-12 14:42:02.974	NOT_VERIFIED	2022-12-12 14:48:40.236	test-tutor@test.com	4V115j6oH0YctCgBYXclb3WUT8D2Bz4nIaoJCasCJs	f	f
 \.
 
 
@@ -329,6 +329,26 @@ COPY public.user_preferences (user_id, preference_type, preference_name, prefere
 5	BOOLEAN_NOTATION	ENG	f	2022-08-03 12:08:57.777349
 5	BOOLEAN_NOTATION	MATH	t	2022-08-03 12:08:57.777349
 5	DISPLAY_SETTING	HIDE_NON_AUDIENCE_CONTENT	t	2022-08-03 12:08:57.777349
+\.
+
+
+--
+-- Data for Name: user_session_token; Type: TABLE DATA; Schema: public; Owner: rutherford
+--
+
+COPY public.user_session_token (user_id, session_token) FROM stdin;
+1	0
+2	0
+3	0
+4	0
+5	0
+6	0
+7	0
+8	0
+9	0
+10	0
+11	0
+12	0
 \.
 
 


### PR DESCRIPTION
[Ticket](https://michaelcurrin.github.io/dev-cheatsheets/cheatsheets/ci-cd/github-actions/triggers.html)

This PR covers the relevant code changes for relocating the session token field out of the users table into a new table in the database.
The actual database changes themselves will need to be carried out alongside deployment of this PR.

Some investigation into bulk contact management has been carried out, but unfortunately does not look promising and no changes have been implemented thus far. See ticket for further details

IMPORTANT: this ticket will need to be paired with corresponding changes to the database structure to work successfully outside of the tests. Do not merge this in without a plan in place.