### PR TITLE
[167]: Private event api functionality

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -112,6 +112,7 @@ public final class Constants {
 
   public static final String DATE_FIELDNAME = "date";
   public static final String ENDDATE_FIELDNAME = "endDate";
+  public static final String PRIVATE_EVENT_FIELDNAME = "privateEvent";
 
   public static final String ALL_BOARDS = "ALL";
   public static final Integer DEFAULT_GAMEBOARDS_RESULTS_LIMIT = 6;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -112,7 +112,7 @@ public final class Constants {
 
   public static final String DATE_FIELDNAME = "date";
   public static final String ENDDATE_FIELDNAME = "endDate";
-  public static final String IS_PRIVATE_EVENT_FIELDNAME = "isPrivateEvent";
+  public static final String PRIVATE_EVENT_FIELDNAME = "privateEvent";
 
   public static final String ALL_BOARDS = "ALL";
   public static final Integer DEFAULT_GAMEBOARDS_RESULTS_LIMIT = 6;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -112,7 +112,7 @@ public final class Constants {
 
   public static final String DATE_FIELDNAME = "date";
   public static final String ENDDATE_FIELDNAME = "endDate";
-  public static final String PRIVATE_EVENT_FIELDNAME = "privateEvent";
+  public static final String IS_PRIVATE_EVENT_FIELDNAME = "isPrivateEvent";
 
   public static final String ALL_BOARDS = "ALL";
   public static final Integer DEFAULT_GAMEBOARDS_RESULTS_LIMIT = 6;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -72,6 +72,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import ma.glasnost.orika.MapperFacade;
@@ -1528,7 +1529,7 @@ public class EventsFacade extends AbstractIsaacFacade {
         eventOverviewBuilder.put("bookingDeadline",
             event.getBookingDeadline() == null ? event.getDate() : event.getBookingDeadline());
         eventOverviewBuilder.put("eventStatus", event.getEventStatus());
-        eventOverviewBuilder.put("privateEvent", event.getPrivateEvent());
+        eventOverviewBuilder.put("privateEvent", Objects.requireNonNullElse(event.getPrivateEvent(), false));
 
         if (null != event.getLocation()) {
           eventOverviewBuilder.put("location", event.getLocation());

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -1529,7 +1529,7 @@ public class EventsFacade extends AbstractIsaacFacade {
         eventOverviewBuilder.put("bookingDeadline",
             event.getBookingDeadline() == null ? event.getDate() : event.getBookingDeadline());
         eventOverviewBuilder.put("eventStatus", event.getEventStatus());
-        eventOverviewBuilder.put("isPrivateEvent", Objects.requireNonNullElse(event.isPrivateEvent(), false));
+        eventOverviewBuilder.put("privateEvent", Objects.requireNonNullElse(event.isPrivateEvent(), false));
 
         if (null != event.getLocation()) {
           eventOverviewBuilder.put("location", event.getLocation());

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -19,6 +19,7 @@ package uk.ac.cam.cl.dtg.isaac.api;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.DATE_FIELDNAME;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.ENDDATE_FIELDNAME;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.EVENT_TYPE;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.PRIVATE_EVENT_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.ADMIN_BOOKING_REASON_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.ATTENDED_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.BOOKING_STATUS_FIELDNAME;
@@ -116,6 +117,7 @@ import uk.ac.cam.cl.dtg.segue.dao.schools.SchoolListReader;
 import uk.ac.cam.cl.dtg.segue.dao.schools.UnableToIndexSchoolsException;
 import uk.ac.cam.cl.dtg.segue.search.AbstractFilterInstruction;
 import uk.ac.cam.cl.dtg.segue.search.DateRangeFilterInstruction;
+import uk.ac.cam.cl.dtg.segue.search.SimpleExclusionInstruction;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 /**
@@ -288,6 +290,11 @@ public class EventsFacade extends AbstractIsaacFacade {
           SegueErrorResponse.getNotLoggedInResponse();
         }
       } else {
+        if (filterInstructions == null) {
+          filterInstructions = Maps.newHashMap();
+        }
+        // If neither bookings only nor reservations only, hide private events
+        filterInstructions.put(PRIVATE_EVENT_FIELDNAME, new SimpleExclusionInstruction("true"));
         findByFieldNames = this.contentManager.findByFieldNames(
             ContentService.generateDefaultFieldToMatch(fieldsToMatch), newStartIndex, newLimit,
             sortInstructions, filterInstructions);
@@ -1521,6 +1528,7 @@ public class EventsFacade extends AbstractIsaacFacade {
         eventOverviewBuilder.put("bookingDeadline",
             event.getBookingDeadline() == null ? event.getDate() : event.getBookingDeadline());
         eventOverviewBuilder.put("eventStatus", event.getEventStatus());
+        eventOverviewBuilder.put("privateEvent", event.getPrivateEvent());
 
         if (null != event.getLocation()) {
           eventOverviewBuilder.put("location", event.getLocation());

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -19,7 +19,7 @@ package uk.ac.cam.cl.dtg.isaac.api;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.DATE_FIELDNAME;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.ENDDATE_FIELDNAME;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.EVENT_TYPE;
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.IS_PRIVATE_EVENT_FIELDNAME;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.PRIVATE_EVENT_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.ADMIN_BOOKING_REASON_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.ATTENDED_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.BOOKING_STATUS_FIELDNAME;
@@ -295,7 +295,7 @@ public class EventsFacade extends AbstractIsaacFacade {
           filterInstructions = Maps.newHashMap();
         }
         // If neither bookings only nor reservations only, hide private events
-        filterInstructions.put(IS_PRIVATE_EVENT_FIELDNAME, new SimpleExclusionInstruction("true"));
+        filterInstructions.put(PRIVATE_EVENT_FIELDNAME, new SimpleExclusionInstruction("true"));
         findByFieldNames = this.contentManager.findByFieldNames(
             ContentService.generateDefaultFieldToMatch(fieldsToMatch), newStartIndex, newLimit,
             sortInstructions, filterInstructions);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -19,7 +19,7 @@ package uk.ac.cam.cl.dtg.isaac.api;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.DATE_FIELDNAME;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.ENDDATE_FIELDNAME;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.EVENT_TYPE;
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.PRIVATE_EVENT_FIELDNAME;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.IS_PRIVATE_EVENT_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.ADMIN_BOOKING_REASON_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.ATTENDED_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.BOOKING_STATUS_FIELDNAME;
@@ -295,7 +295,7 @@ public class EventsFacade extends AbstractIsaacFacade {
           filterInstructions = Maps.newHashMap();
         }
         // If neither bookings only nor reservations only, hide private events
-        filterInstructions.put(PRIVATE_EVENT_FIELDNAME, new SimpleExclusionInstruction("true"));
+        filterInstructions.put(IS_PRIVATE_EVENT_FIELDNAME, new SimpleExclusionInstruction("true"));
         findByFieldNames = this.contentManager.findByFieldNames(
             ContentService.generateDefaultFieldToMatch(fieldsToMatch), newStartIndex, newLimit,
             sortInstructions, filterInstructions);
@@ -1529,7 +1529,7 @@ public class EventsFacade extends AbstractIsaacFacade {
         eventOverviewBuilder.put("bookingDeadline",
             event.getBookingDeadline() == null ? event.getDate() : event.getBookingDeadline());
         eventOverviewBuilder.put("eventStatus", event.getEventStatus());
-        eventOverviewBuilder.put("privateEvent", Objects.requireNonNullElse(event.getPrivateEvent(), false));
+        eventOverviewBuilder.put("isPrivateEvent", Objects.requireNonNullElse(event.getIsPrivateEvent(), false));
 
         if (null != event.getLocation()) {
           eventOverviewBuilder.put("location", event.getLocation());

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -1529,7 +1529,7 @@ public class EventsFacade extends AbstractIsaacFacade {
         eventOverviewBuilder.put("bookingDeadline",
             event.getBookingDeadline() == null ? event.getDate() : event.getBookingDeadline());
         eventOverviewBuilder.put("eventStatus", event.getEventStatus());
-        eventOverviewBuilder.put("isPrivateEvent", Objects.requireNonNullElse(event.getIsPrivateEvent(), false));
+        eventOverviewBuilder.put("isPrivateEvent", Objects.requireNonNullElse(event.isPrivateEvent(), false));
 
         if (null != event.getLocation()) {
           eventOverviewBuilder.put("location", event.getLocation());

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
@@ -69,7 +69,7 @@ public class IsaacEventPage extends Content {
 
   private Boolean allowGroupReservations;
 
-  private Boolean isPrivateEvent;
+  private Boolean privateEvent;
 
   @JsonCreator
   public IsaacEventPage(@JsonProperty("id") final String id,
@@ -97,7 +97,7 @@ public class IsaacEventPage extends Content {
                         @JsonProperty("EventStatus") final EventStatus eventStatus,
                         @JsonProperty("groupReservationLimit") final Integer groupReservationLimit,
                         @JsonProperty("allowGroupReservations") final Boolean allowGroupReservations,
-                        @JsonProperty("isPrivateEvent") final Boolean isPrivateEvent) {
+                        @JsonProperty("privateEvent") final Boolean privateEvent) {
     super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null,
         null, relatedContent, published, deprecated, tags, null);
 
@@ -114,7 +114,7 @@ public class IsaacEventPage extends Content {
     this.groupReservationLimit =
         groupReservationLimit != null ? groupReservationLimit : EVENT_GROUP_RESERVATION_DEFAULT_LIMIT;
     this.allowGroupReservations = allowGroupReservations != null ? allowGroupReservations : false;
-    this.isPrivateEvent = isPrivateEvent;
+    this.privateEvent = privateEvent;
   }
 
   /**
@@ -470,11 +470,11 @@ public class IsaacEventPage extends Content {
     this.allowGroupReservations = allowGroupReservations;
   }
 
-  public Boolean getIsPrivateEvent() {
-    return isPrivateEvent;
+  public Boolean isPrivateEvent() {
+    return privateEvent;
   }
 
-  public void setIsPrivateEvent(Boolean isPrivateEvent) {
-    this.isPrivateEvent = isPrivateEvent;
+  public void setPrivateEvent(Boolean privateEvent) {
+    this.privateEvent = privateEvent;
   }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
@@ -69,6 +69,8 @@ public class IsaacEventPage extends Content {
 
   private Boolean allowGroupReservations;
 
+  private Boolean privateEvent;
+
   @JsonCreator
   public IsaacEventPage(@JsonProperty("id") final String id,
                         @JsonProperty("title") final String title,
@@ -94,7 +96,8 @@ public class IsaacEventPage extends Content {
                         @JsonProperty("numberOfPlaces") final Integer numberOfPlaces,
                         @JsonProperty("EventStatus") final EventStatus eventStatus,
                         @JsonProperty("groupReservationLimit") final Integer groupReservationLimit,
-                        @JsonProperty("allowGroupReservations") final Boolean allowGroupReservations) {
+                        @JsonProperty("allowGroupReservations") final Boolean allowGroupReservations,
+                        @JsonProperty("privateEvent") final Boolean privateEvent) {
     super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null,
         null, relatedContent, published, deprecated, tags, null);
 
@@ -111,6 +114,7 @@ public class IsaacEventPage extends Content {
     this.groupReservationLimit =
         groupReservationLimit != null ? groupReservationLimit : EVENT_GROUP_RESERVATION_DEFAULT_LIMIT;
     this.allowGroupReservations = allowGroupReservations != null ? allowGroupReservations : false;
+    this.privateEvent = privateEvent;
   }
 
   /**
@@ -466,5 +470,11 @@ public class IsaacEventPage extends Content {
     this.allowGroupReservations = allowGroupReservations;
   }
 
+  public Boolean getPrivateEvent() {
+    return privateEvent;
+  }
 
+  public void setPrivateEvent(Boolean privateEvent) {
+    this.privateEvent = privateEvent;
+  }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
@@ -69,7 +69,7 @@ public class IsaacEventPage extends Content {
 
   private Boolean allowGroupReservations;
 
-  private Boolean privateEvent;
+  private Boolean isPrivateEvent;
 
   @JsonCreator
   public IsaacEventPage(@JsonProperty("id") final String id,
@@ -97,7 +97,7 @@ public class IsaacEventPage extends Content {
                         @JsonProperty("EventStatus") final EventStatus eventStatus,
                         @JsonProperty("groupReservationLimit") final Integer groupReservationLimit,
                         @JsonProperty("allowGroupReservations") final Boolean allowGroupReservations,
-                        @JsonProperty("privateEvent") final Boolean privateEvent) {
+                        @JsonProperty("isPrivateEvent") final Boolean isPrivateEvent) {
     super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null,
         null, relatedContent, published, deprecated, tags, null);
 
@@ -114,7 +114,7 @@ public class IsaacEventPage extends Content {
     this.groupReservationLimit =
         groupReservationLimit != null ? groupReservationLimit : EVENT_GROUP_RESERVATION_DEFAULT_LIMIT;
     this.allowGroupReservations = allowGroupReservations != null ? allowGroupReservations : false;
-    this.privateEvent = privateEvent;
+    this.isPrivateEvent = isPrivateEvent;
   }
 
   /**
@@ -470,11 +470,11 @@ public class IsaacEventPage extends Content {
     this.allowGroupReservations = allowGroupReservations;
   }
 
-  public Boolean getPrivateEvent() {
-    return privateEvent;
+  public Boolean getIsPrivateEvent() {
+    return isPrivateEvent;
   }
 
-  public void setPrivateEvent(Boolean privateEvent) {
-    this.privateEvent = privateEvent;
+  public void setIsPrivateEvent(Boolean isPrivateEvent) {
+    this.isPrivateEvent = isPrivateEvent;
   }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -72,7 +72,7 @@ public class IsaacEventPageDTO extends ContentDTO {
 
   private Boolean allowGroupReservations;
 
-  private Boolean privateEvent;
+  private Boolean isPrivateEvent;
 
   /**
    * @param id
@@ -100,7 +100,7 @@ public class IsaacEventPageDTO extends ContentDTO {
    * @param eventStatus
    * @param groupReservationLimit
    * @param allowGroupReservations
-   * @param privateEvent if an event should be publicly visible or hidden
+   * @param isPrivateEvent if an event should be publicly visible or hidden
    */
   @JsonCreator
   public IsaacEventPageDTO(
@@ -129,7 +129,7 @@ public class IsaacEventPageDTO extends ContentDTO {
       @JsonProperty("EventStatus") final EventStatus eventStatus,
       @JsonProperty("groupReservationLimit") final Integer groupReservationLimit,
       @JsonProperty("allowGroupReservations") final Boolean allowGroupReservations,
-      @JsonProperty("privateEvent") final Boolean privateEvent) {
+      @JsonProperty("isPrivateEvent") final Boolean isPrivateEvent) {
     super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null, null,
         relatedContent, published, deprecated, tags, null);
 
@@ -146,7 +146,7 @@ public class IsaacEventPageDTO extends ContentDTO {
     this.groupReservationLimit =
         groupReservationLimit != null ? groupReservationLimit : EVENT_GROUP_RESERVATION_DEFAULT_LIMIT;
     this.allowGroupReservations = allowGroupReservations;
-    this.privateEvent = privateEvent;
+    this.isPrivateEvent = isPrivateEvent;
   }
 
   /**
@@ -541,11 +541,11 @@ public class IsaacEventPageDTO extends ContentDTO {
     return super.getCanonicalSourceFile();
   }
 
-  public Boolean getPrivateEvent() {
-    return privateEvent;
+  public Boolean getIsPrivateEvent() {
+    return isPrivateEvent;
   }
 
-  public void setPrivateEvent(Boolean privateEvent) {
-    this.privateEvent = privateEvent;
+  public void setIsPrivateEvent(Boolean isPrivateEvent) {
+    this.isPrivateEvent = isPrivateEvent;
   }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -72,6 +72,8 @@ public class IsaacEventPageDTO extends ContentDTO {
 
   private Boolean allowGroupReservations;
 
+  private Boolean privateEvent;
+
   /**
    * @param id
    * @param title
@@ -98,6 +100,7 @@ public class IsaacEventPageDTO extends ContentDTO {
    * @param eventStatus
    * @param groupReservationLimit
    * @param allowGroupReservations
+   * @param privateEvent if an event should be publicly visible or hidden
    */
   @JsonCreator
   public IsaacEventPageDTO(
@@ -125,7 +128,8 @@ public class IsaacEventPageDTO extends ContentDTO {
       @JsonProperty("numberOfPlaces") final Integer numberOfPlaces,
       @JsonProperty("EventStatus") final EventStatus eventStatus,
       @JsonProperty("groupReservationLimit") final Integer groupReservationLimit,
-      @JsonProperty("allowGroupReservations") final Boolean allowGroupReservations) {
+      @JsonProperty("allowGroupReservations") final Boolean allowGroupReservations,
+      @JsonProperty("privateEvent") final Boolean privateEvent) {
     super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null, null,
         relatedContent, published, deprecated, tags, null);
 
@@ -142,6 +146,7 @@ public class IsaacEventPageDTO extends ContentDTO {
     this.groupReservationLimit =
         groupReservationLimit != null ? groupReservationLimit : EVENT_GROUP_RESERVATION_DEFAULT_LIMIT;
     this.allowGroupReservations = allowGroupReservations;
+    this.privateEvent = privateEvent;
   }
 
   /**
@@ -536,4 +541,11 @@ public class IsaacEventPageDTO extends ContentDTO {
     return super.getCanonicalSourceFile();
   }
 
+  public Boolean getPrivateEvent() {
+    return privateEvent;
+  }
+
+  public void setPrivateEvent(Boolean privateEvent) {
+    this.privateEvent = privateEvent;
+  }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -72,7 +72,7 @@ public class IsaacEventPageDTO extends ContentDTO {
 
   private Boolean allowGroupReservations;
 
-  private Boolean isPrivateEvent;
+  private Boolean privateEvent;
 
   /**
    * @param id
@@ -100,7 +100,7 @@ public class IsaacEventPageDTO extends ContentDTO {
    * @param eventStatus
    * @param groupReservationLimit
    * @param allowGroupReservations
-   * @param isPrivateEvent if an event should be publicly visible or hidden
+   * @param privateEvent if an event should be publicly visible or hidden
    */
   @JsonCreator
   public IsaacEventPageDTO(
@@ -129,7 +129,7 @@ public class IsaacEventPageDTO extends ContentDTO {
       @JsonProperty("EventStatus") final EventStatus eventStatus,
       @JsonProperty("groupReservationLimit") final Integer groupReservationLimit,
       @JsonProperty("allowGroupReservations") final Boolean allowGroupReservations,
-      @JsonProperty("isPrivateEvent") final Boolean isPrivateEvent) {
+      @JsonProperty("privateEvent") final Boolean privateEvent) {
     super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null, null,
         relatedContent, published, deprecated, tags, null);
 
@@ -146,7 +146,7 @@ public class IsaacEventPageDTO extends ContentDTO {
     this.groupReservationLimit =
         groupReservationLimit != null ? groupReservationLimit : EVENT_GROUP_RESERVATION_DEFAULT_LIMIT;
     this.allowGroupReservations = allowGroupReservations;
-    this.isPrivateEvent = isPrivateEvent;
+    this.privateEvent = privateEvent;
   }
 
   /**
@@ -541,11 +541,11 @@ public class IsaacEventPageDTO extends ContentDTO {
     return super.getCanonicalSourceFile();
   }
 
-  public Boolean getIsPrivateEvent() {
-    return isPrivateEvent;
+  public Boolean isPrivateEvent() {
+    return privateEvent;
   }
 
-  public void setIsPrivateEvent(Boolean isPrivateEvent) {
-    this.isPrivateEvent = isPrivateEvent;
+  public void setPrivateEvent(Boolean privateEvent) {
+    this.privateEvent = privateEvent;
   }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
@@ -349,8 +349,8 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
     assertNotNull(entity);
     List<ImmutableMap<String, Object>> results = entity.getResults();
     assertEquals(9, results.size());
-    Long numberOfPublicEventsInResults = results.stream().filter(overview -> !(Boolean) overview.get("isPrivateEvent")).count();
-    Long numberOfPrivateEventsInResults = results.stream().filter(overview -> (Boolean) overview.get("isPrivateEvent")).count();
+    Long numberOfPublicEventsInResults = results.stream().filter(overview -> !(Boolean) overview.get("privateEvent")).count();
+    Long numberOfPrivateEventsInResults = results.stream().filter(overview -> (Boolean) overview.get("privateEvent")).count();
     assertEquals(8, numberOfPublicEventsInResults);
     assertEquals(1, numberOfPrivateEventsInResults);
   }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.google.common.collect.ImmutableMap;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Response;
@@ -74,6 +75,8 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
     // NOTE: We may end up having more events in the dataset than the limit specified in the call.
     //       In this case, we need to check for the limit up here and then check if the response object tells us
     //       that there are more, and how many there are.
+    assertEquals(8, results.stream().filter(event -> event.getPrivateEvent() == null || !event.getPrivateEvent()).count());
+    assertEquals(0, results.stream().filter(event -> event.getPrivateEvent() != null && event.getPrivateEvent()).count());
   }
 
   @Test
@@ -323,5 +326,28 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
         eventsFacade.getEventBookingForGivenGroup(eventManagerRequest, "_regular_test_event", "2");
     // The event manager does not own the group so this should not succeed
     assertNotEquals(Response.Status.OK.getStatusCode(), eventManagerResponse.getStatus());
+  }
+
+  @Test
+  public void getEventOverviewsTest() throws NoCredentialsAvailableException, NoUserException, SegueDatabaseException,
+      AuthenticationProviderMappingException, IncorrectCredentialsProvidedException,
+      AdditionalAuthenticationRequiredException, InvalidKeySpecException, NoSuchAlgorithmException,
+      MFARequiredButNotConfiguredException {
+    LoginResult eventManagerLogin = loginAs(httpSession, ITConstants.TEST_EVENTMANAGER_EMAIL, ITConstants.TEST_EVENTMANAGER_PASSWORD);
+
+    HttpServletRequest mockRequest = createRequestWithCookies(new Cookie[] {eventManagerLogin.cookie});
+    replay(mockRequest);
+
+    Response response = eventsFacade.getEventOverviews(mockRequest, 0, 10, null);
+
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Object entityObject = response.getEntity();
+    assertNotNull(entityObject);
+    @SuppressWarnings("unchecked") ResultsWrapper<ImmutableMap<String, Object>> entity = (ResultsWrapper<ImmutableMap<String, Object>>) entityObject;
+    assertNotNull(entity);
+    List<ImmutableMap<String, Object>> results = entity.getResults();
+    assertEquals(9, results.size());
+    assertEquals(8, results.stream().filter(overview -> !(Boolean) overview.get("privateEvent")).count());
+    assertEquals(1, results.stream().filter(overview -> (Boolean) overview.get("privateEvent")).count());
   }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
@@ -75,8 +75,10 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
     // NOTE: We may end up having more events in the dataset than the limit specified in the call.
     //       In this case, we need to check for the limit up here and then check if the response object tells us
     //       that there are more, and how many there are.
-    assertEquals(8, results.stream().filter(event -> event.getIsPrivateEvent() == null || !event.getIsPrivateEvent()).count());
-    assertEquals(0, results.stream().filter(event -> event.getIsPrivateEvent() != null && event.getIsPrivateEvent()).count());
+    Long numberOfPublicEventsInResults = results.stream().filter(event -> event.getIsPrivateEvent() == null || !event.getIsPrivateEvent()).count();
+    Long numberOfPrivateEventsInResults = results.stream().filter(event -> event.getIsPrivateEvent() != null && event.getIsPrivateEvent()).count();
+    assertEquals(8, numberOfPublicEventsInResults);
+    assertEquals(0, numberOfPrivateEventsInResults);
   }
 
   @Test
@@ -347,7 +349,9 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
     assertNotNull(entity);
     List<ImmutableMap<String, Object>> results = entity.getResults();
     assertEquals(9, results.size());
-    assertEquals(8, results.stream().filter(overview -> !(Boolean) overview.get("isPrivateEvent")).count());
-    assertEquals(1, results.stream().filter(overview -> (Boolean) overview.get("isPrivateEvent")).count());
+    Long numberOfPublicEventsInResults = results.stream().filter(overview -> !(Boolean) overview.get("isPrivateEvent")).count();
+    Long numberOfPrivateEventsInResults = results.stream().filter(overview -> (Boolean) overview.get("isPrivateEvent")).count();
+    assertEquals(8, numberOfPublicEventsInResults);
+    assertEquals(1, numberOfPrivateEventsInResults);
   }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
@@ -75,8 +75,8 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
     // NOTE: We may end up having more events in the dataset than the limit specified in the call.
     //       In this case, we need to check for the limit up here and then check if the response object tells us
     //       that there are more, and how many there are.
-    Long numberOfPublicEventsInResults = results.stream().filter(event -> event.getIsPrivateEvent() == null || !event.getIsPrivateEvent()).count();
-    Long numberOfPrivateEventsInResults = results.stream().filter(event -> event.getIsPrivateEvent() != null && event.getIsPrivateEvent()).count();
+    Long numberOfPublicEventsInResults = results.stream().filter(event -> event.isPrivateEvent() == null || !event.isPrivateEvent()).count();
+    Long numberOfPrivateEventsInResults = results.stream().filter(event -> event.isPrivateEvent() != null && event.isPrivateEvent()).count();
     assertEquals(8, numberOfPublicEventsInResults);
     assertEquals(0, numberOfPrivateEventsInResults);
   }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
@@ -75,8 +75,8 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
     // NOTE: We may end up having more events in the dataset than the limit specified in the call.
     //       In this case, we need to check for the limit up here and then check if the response object tells us
     //       that there are more, and how many there are.
-    assertEquals(8, results.stream().filter(event -> event.getPrivateEvent() == null || !event.getPrivateEvent()).count());
-    assertEquals(0, results.stream().filter(event -> event.getPrivateEvent() != null && event.getPrivateEvent()).count());
+    assertEquals(8, results.stream().filter(event -> event.getIsPrivateEvent() == null || !event.getIsPrivateEvent()).count());
+    assertEquals(0, results.stream().filter(event -> event.getIsPrivateEvent() != null && event.getIsPrivateEvent()).count());
   }
 
   @Test
@@ -347,7 +347,7 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
     assertNotNull(entity);
     List<ImmutableMap<String, Object>> results = entity.getResults();
     assertEquals(9, results.size());
-    assertEquals(8, results.stream().filter(overview -> !(Boolean) overview.get("privateEvent")).count());
-    assertEquals(1, results.stream().filter(overview -> (Boolean) overview.get("privateEvent")).count());
+    assertEquals(8, results.stream().filter(overview -> !(Boolean) overview.get("isPrivateEvent")).count());
+    assertEquals(1, results.stream().filter(overview -> (Boolean) overview.get("isPrivateEvent")).count());
   }
 }


### PR DESCRIPTION
[Ticket](https://github.com/isaaccomputerscience/isaac-cs-issues/issues/167)
Update IsaacEventPage(DTO) to include privateEvent flag
Add filter to getEvents endpoint method to hide events with privateEvent set too true, unless viewing only bookings or reservations for the current user
Add privateEvent flag to the maps of information returned by the getEventOverviews endpoint method

Note: it is expected that the [CDN PR](https://github.com/isaaccomputerscience/isaac-cdn/pull/6) will be required for the the testing workflow to pass