### PR TITLE
[304]: Reintroduce dirAllowed parameter in web-api files

### DIFF
--- a/web-api-live.xml
+++ b/web-api-live.xml
@@ -59,4 +59,9 @@
         </param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.eclipse.jetty.servlet.Default.dirAllowed</param-name>
+        <param-value>false</param-value>
+    </context-param>
+
 </web-app>

--- a/web-api-local.xml
+++ b/web-api-local.xml
@@ -59,4 +59,9 @@
         </param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.eclipse.jetty.servlet.Default.dirAllowed</param-name>
+        <param-value>false</param-value>
+    </context-param>
+
 </web-app>


### PR DESCRIPTION
[Ticket](https://github.com/isaaccomputerscience/isaac-cs-issues/issues/20)
Reintroducing the dirAllowed parameter as false to the web-api files. This was previously added but removed in a followup ticket shortly after, though I can't remember with confidence why it was removed. Given the timeframe it's unlikely this removal was the cause of the issue reoccurring but it does appear to solve or mitigate the issue - behaviour on live and local seems to be slightly different so it would be advised to double-check this once deployed to staging.

For future reference, the local equivalent to `https://isaaccomputerscience.org/api/v3.5.0/` appears to be located at `http://localhost:8080/isaac-api/` (rather than using the base url of `http://localhost:8003/` usually used for testing).