### PR TITLE
[302]: Upgrade Prometheus dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <oauth-client.version>1.35.0</oauth-client.version>
         <jackson.version>2.16.1</jackson.version>
         <swagger.version>2.2.2</swagger.version>
-        <prometheus.version>0.8.0</prometheus.version>
+        <prometheus.version>0.16.0</prometheus.version>
         <jetty.version>11.0.20</jetty.version>
         <jetty.port.api>8080</jetty.port.api>
         <jetty.port.etl>8090</jetty.port.etl>

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PrometheusMetricsExporter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PrometheusMetricsExporter.java
@@ -35,7 +35,11 @@ public class PrometheusMetricsExporter implements IMetricsExporter {
    * @param port the port to expose the metrics.
    * @throws IOException could be thrown by the socket.
    */
+  @SuppressWarnings("java:S2095")
   public PrometheusMetricsExporter(final int port) throws IOException {
+    // IMPORTANT: it has been suggested that the grafana issues seen during a previous dependency update attempt were
+    // the result of applying a try-catch pattern to this resource, causing the metrics server to close prematurely.
+    // Do not apply this linter recommendation at this time.
     new HTTPServer(port);
     log.info("Prometheus Metrics Exporter has been initialised on port {}", port);
   }


### PR DESCRIPTION
[Ticket](https://github.com/isaaccomputerscience/isaac-cs-issues/issues/302)
Upgrade prometheus dependency from 0.8.0 to 0.16.0
As per ticket, add warning about linter recommendation on metrics server initialisation.