### PR TITLE
shav/368 question-finder-bug

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -633,6 +633,13 @@ public class QuestionManager {
       List<String> stagesList = new ArrayList<>();
       List<String> examBoardsList = new ArrayList<>();
 
+      for (UserContext uc : userContexts) {
+        if (!filterQuestionsPreference.getPreferenceValue()) {
+          stagesList.add(uc.getStage().name());
+          examBoardsList.add(uc.getExamBoard().name());
+        }
+      }
+
       gameFilter = new GameFilter(
           subjectsList,
           null,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -634,7 +634,9 @@ public class QuestionManager {
       List<String> examBoardsList = new ArrayList<>();
 
       for (UserContext uc : userContexts) {
-        stagesList.add(uc.getStage().name());
+        if (!filterQuestionsPreference.getPreferenceValue()) {
+          stagesList.add(uc.getStage().name());
+        }
         if (!filterQuestionsPreference.getPreferenceValue()) {
           examBoardsList.add(uc.getExamBoard().name());
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -633,9 +633,14 @@ public class QuestionManager {
       List<String> stagesList = new ArrayList<>();
       List<String> examBoardsList = new ArrayList<>();
 
+      boolean containsAllStages = userContexts.stream().anyMatch(uc -> "all".equals(uc.getStage().name()));
+      boolean containsAllExamBoards = userContexts.stream().anyMatch(uc -> "all".equals(uc.getExamBoard().name()));
+
       for (UserContext uc : userContexts) {
-        if (!filterQuestionsPreference.getPreferenceValue()) {
+        if (!containsAllStages) {
           stagesList.add(uc.getStage().name());
+        }
+        if (!containsAllExamBoards) {
           examBoardsList.add(uc.getExamBoard().name());
         }
       }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -633,15 +633,6 @@ public class QuestionManager {
       List<String> stagesList = new ArrayList<>();
       List<String> examBoardsList = new ArrayList<>();
 
-      for (UserContext uc : userContexts) {
-        if (!filterQuestionsPreference.getPreferenceValue()) {
-          stagesList.add(uc.getStage().name());
-        }
-        if (!filterQuestionsPreference.getPreferenceValue()) {
-          examBoardsList.add(uc.getExamBoard().name());
-        }
-      }
-
       gameFilter = new GameFilter(
           subjectsList,
           null,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -635,7 +635,9 @@ public class QuestionManager {
 
       for (UserContext uc : userContexts) {
         stagesList.add(uc.getStage().name());
-        examBoardsList.add(uc.getExamBoard().name());
+        if (!filterQuestionsPreference.getPreferenceValue()) {
+          examBoardsList.add(uc.getExamBoard().name());
+        }
       }
 
       gameFilter = new GameFilter(


### PR DESCRIPTION
Ticket: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/368

The question finder tile on homepage isn't working for students with the following account preferences:

GCSE + All Exam Boards
A Level + All Exam Boards
All Stage + All Exam Boards

This specifically occurs when the "show other content" option is not ticked.

/random returns [] in this scenario.

Correct functionality should be that a request to /random with those settings will select 5 random questions regardless of exam board, either looking at GCSE, A level or both depending on preference.

There is a fallback component of "featured news" on the homepage, so it's not a breaking issue for now.
