### PR TITLE
Robert/370 teachers booking full student event

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -896,6 +896,10 @@ public class EventBookingManager {
 
     // capacity of the event
     if (isStudentEvent) {
+      if (studentCount > numberOfPlaces) {
+        return 0L;
+      }
+
       return numberOfPlaces - studentCount;
     }
 
@@ -1335,7 +1339,7 @@ public class EventBookingManager {
     if (numberOfPlaces != null) {
       long numberOfRequests = users.stream()
           // Consider tutors as students with regard to teacher events (for now)
-          .filter(user -> !isStudentEvent || !Role.TEACHER.equals(user.getRole()))
+          .filter(user -> !isStudentEvent || Role.STUDENT.equals(user.getRole()) || Role.TUTOR.equals(user.getRole()))
           .count();
       if (numberOfPlaces - numberOfRequests < 0) {
         throw new EventIsFullException(

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -151,7 +151,7 @@ public class EventBookingPersistenceManager {
    * @return Map of booking status, role to count
    * @throws SegueDatabaseException - if something is wrong with the database
    */
-  public Map<BookingStatus, Map<Role, Long>> getEventBookingStatusCounts(final String eventId,
+  public Map<BookingStatus, Map<Role, Integer>> getEventBookingStatusCounts(final String eventId,
                                                                          final boolean includeDeletedUsersInCounts)
       throws SegueDatabaseException {
     return dao.getEventBookingStatusCounts(eventId, includeDeletedUsersInCounts);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -119,7 +119,8 @@ public interface EventBookings {
    * @return Map of booking status to number of bookings for the event.
    * @throws SegueDatabaseException - if there is a problem accessing the db
    */
-  Map<BookingStatus, Map<Role, Long>> getEventBookingStatusCounts(String eventId, boolean includeDeletedUsersInCounts)
+  Map<BookingStatus, Map<Role, Integer>> getEventBookingStatusCounts(String eventId,
+                                                                     boolean includeDeletedUsersInCounts)
       throws SegueDatabaseException;
 
   /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
@@ -536,7 +536,7 @@ public class PgEventBookings implements EventBookings {
   }
 
   @Override
-  public Map<BookingStatus, Map<Role, Long>> getEventBookingStatusCounts(final String eventId,
+  public Map<BookingStatus, Map<Role, Integer>> getEventBookingStatusCounts(final String eventId,
                                                                          final boolean includeDeletedUsersInCounts)
       throws SegueDatabaseException {
     // Note this method joins at the db table mainly to allow inclusion of deleted users in the counts.
@@ -558,13 +558,13 @@ public class PgEventBookings implements EventBookings {
       pst.setString(FIELD_GET_STATUS_COUNTS_EVENT_ID, eventId);
 
       try (ResultSet results = pst.executeQuery()) {
-        Map<BookingStatus, Map<Role, Long>> returnResult = Maps.newHashMap();
+        Map<BookingStatus, Map<Role, Integer>> returnResult = Maps.newHashMap();
         while (results.next()) {
           BookingStatus bookingStatus = BookingStatus.valueOf(results.getString("status"));
           Role role = Role.valueOf(results.getString("role"));
-          Long count = results.getLong("count");
+          Integer count = results.getInt("count");
 
-          Map<Role, Long> roleCountMap = returnResult.getOrDefault(bookingStatus, Maps.newHashMap());
+          Map<Role, Integer> roleCountMap = returnResult.getOrDefault(bookingStatus, Maps.newHashMap());
           roleCountMap.put(role, count);
           returnResult.put(bookingStatus, roleCountMap);
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -67,7 +67,7 @@ public class IsaacEventPageDTO extends ContentDTO {
 
   private BookingStatus userBookingStatus;
 
-  private Long placesAvailable;
+  private Integer placesAvailable;
 
   private Integer groupReservationLimit;
 
@@ -444,7 +444,7 @@ public class IsaacEventPageDTO extends ContentDTO {
    *
    * @return the get the places available.
    */
-  public Long getPlacesAvailable() {
+  public Integer getPlacesAvailable() {
     return placesAvailable;
   }
 
@@ -453,7 +453,7 @@ public class IsaacEventPageDTO extends ContentDTO {
    *
    * @param placesAvailable - the number of places available.
    */
-  public void setPlacesAvailable(final Long placesAvailable) {
+  public void setPlacesAvailable(final Integer placesAvailable) {
     this.placesAvailable = placesAvailable;
   }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
@@ -178,8 +178,8 @@ class EventBookingManagerTest {
 
       prepareCommonTransactionExpectations(testEvent);
 
-      EventBookingDTO newBooking = prepareEventBookingDto(BookingStatus.CONFIRMED, someUser.getId(),
-          someUser.getRole());
+      EventBookingDTO newBooking = prepareEventBookingDto(someUser.getId(), BookingStatus.CONFIRMED,
+                someUser.getRole());
       expect(
           dummyEventBookingPersistenceManager.createBooking(dummyTransaction, testEvent.getId(), someUser.getId(),
               BookingStatus.CONFIRMED, someAdditionalInformation)).andReturn(newBooking).atLeastOnce();
@@ -480,8 +480,8 @@ class EventBookingManagerTest {
       someUser.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
       someUser.setRole(Role.STUDENT);
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.STUDENT, 6L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.STUDENT, 6);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
@@ -128,8 +128,8 @@ class EventBookingManagerTest {
       someUser.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
       someUser.setRole(role);
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -167,9 +167,9 @@ class EventBookingManagerTest {
       someUser.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
       someUser.setRole(role);
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1L);
-      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.STUDENT, 3L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1);
+      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.STUDENT, 3);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -208,8 +208,8 @@ class EventBookingManagerTest {
       someUser.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
       someUser.setRole(Role.STUDENT);
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -235,8 +235,8 @@ class EventBookingManagerTest {
       someUser.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
       someUser.setRole(Role.TEACHER);
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.TEACHER, 1L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.TEACHER, 1);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -298,9 +298,9 @@ class EventBookingManagerTest {
       someUser.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
       someUser.setRole(Role.TEACHER);
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.TEACHER, 1L);
-      placesAvailableMap.get(BookingStatus.CANCELLED).put(Role.TEACHER, 1L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.TEACHER, 1);
+      placesAvailableMap.get(BookingStatus.CANCELLED).put(Role.TEACHER, 1);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -326,8 +326,8 @@ class EventBookingManagerTest {
       someUser.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
       someUser.setRole(Role.TEACHER);
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CANCELLED).put(Role.TEACHER, 1L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CANCELLED).put(Role.TEACHER, 1);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -364,9 +364,9 @@ class EventBookingManagerTest {
       someUser.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
       someUser.setRole(Role.TEACHER);
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CANCELLED).put(Role.TEACHER, 1L);
-      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.TEACHER, 1L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CANCELLED).put(Role.TEACHER, 1);
+      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.TEACHER, 1);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -437,8 +437,8 @@ class EventBookingManagerTest {
       someUser.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
       someUser.setRole(Role.STUDENT);
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CANCELLED).put(Role.STUDENT, 6L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CANCELLED).put(Role.STUDENT, 6);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -529,8 +529,8 @@ class EventBookingManagerTest {
       DetailedEventBookingDTO firstBooking =
           prepareDetailedEventBookingDto(someUser.getId(), BookingStatus.WAITING_LIST, testEvent.getId());
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -570,9 +570,9 @@ class EventBookingManagerTest {
       DetailedEventBookingDTO firstBooking =
           prepareDetailedEventBookingDto(someUser.getId(), BookingStatus.WAITING_LIST, testEvent.getId());
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1L);
-      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.STUDENT, 3L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1);
+      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.STUDENT, 3);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -612,8 +612,8 @@ class EventBookingManagerTest {
       DetailedEventBookingDTO firstBooking =
           prepareDetailedEventBookingDto(someUser.getId(), BookingStatus.WAITING_LIST, testEvent.getId());
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -653,9 +653,9 @@ class EventBookingManagerTest {
       DetailedEventBookingDTO firstBooking =
           prepareDetailedEventBookingDto(someUser.getId(), BookingStatus.WAITING_LIST, testEvent.getId());
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1L);
-      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.STUDENT, 3L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1);
+      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.STUDENT, 3);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -692,8 +692,8 @@ class EventBookingManagerTest {
       someUser.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
       someUser.setRole(Role.TEACHER);
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -724,9 +724,9 @@ class EventBookingManagerTest {
       DetailedEventBookingDTO existingBooking =
           prepareDetailedEventBookingDto(someUser.getId(), BookingStatus.CONFIRMED, testEvent.getId());
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1L);
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.TEACHER, 6L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.STUDENT, 1);
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.TEACHER, 6);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -802,9 +802,9 @@ class EventBookingManagerTest {
           prepareDetailedEventBookingDto(firstUser, BookingStatus.CANCELLED, testEvent.getId());
       secondBooking.setAdditionalInformation(someAdditionalInformation);
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CANCELLED).put(Role.TEACHER, 1L);
-      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.TEACHER, 1L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CANCELLED).put(Role.TEACHER, 1);
+      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.TEACHER, 1);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -847,9 +847,9 @@ class EventBookingManagerTest {
       DetailedEventBookingDTO firstBooking =
           prepareDetailedEventBookingDto(firstUser, BookingStatus.WAITING_LIST, testEvent.getId());
 
-      Map<BookingStatus, Map<Role, Long>> placesAvailableMap = generatePlacesAvailableMap();
-      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.TEACHER, 1L);
-      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.TEACHER, 1L);
+      Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = generatePlacesAvailableMap();
+      placesAvailableMap.get(BookingStatus.CONFIRMED).put(Role.TEACHER, 1);
+      placesAvailableMap.get(BookingStatus.WAITING_LIST).put(Role.TEACHER, 1);
       expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testEvent.getId(), false)).andReturn(
           placesAvailableMap).atLeastOnce();
 
@@ -989,8 +989,8 @@ class EventBookingManagerTest {
       List<RegisteredUserDTO> studentsToReserve = ImmutableList.of(testCase.student1, testCase.student2);
 
       RegisteredUserDTO previouslyReservedStudent = testCase.student3;
-      Map<BookingStatus, Map<Role, Long>> previousBookingCounts = generatePlacesAvailableMap();
-      previousBookingCounts.put(BookingStatus.CONFIRMED, ImmutableMap.of(Role.STUDENT, 1L));
+      Map<BookingStatus, Map<Role, Integer>> previousBookingCounts = generatePlacesAvailableMap();
+      previousBookingCounts.put(BookingStatus.CONFIRMED, ImmutableMap.of(Role.STUDENT, 1));
       DetailedEventBookingDTO existingEventBooking = prepareDetailedEventBookingDto(
           previouslyReservedStudent.getId(), BookingStatus.CONFIRMED, testCase.event.getId());
       existingEventBooking.setReservedById(testCase.teacher.getId());
@@ -1035,8 +1035,8 @@ class EventBookingManagerTest {
       DetailedEventBookingDTO student2sCancelledReservation =
           prepareDetailedEventBookingDto(testCase.student2.getId(), BookingStatus.CANCELLED, testCase.event.getId());
       student2sCancelledReservation.setReservedById(testCase.teacher.getId());
-      Map<BookingStatus, Map<Role, Long>> previousBookingCounts = generatePlacesAvailableMap();
-      previousBookingCounts.put(BookingStatus.CANCELLED, ImmutableMap.of(Role.STUDENT, 1L));
+      Map<BookingStatus, Map<Role, Integer>> previousBookingCounts = generatePlacesAvailableMap();
+      previousBookingCounts.put(BookingStatus.CANCELLED, ImmutableMap.of(Role.STUDENT, 1));
 
       // Define expected external calls
       dummyEventBookingPersistenceManager.lockEventUntilTransactionComplete(dummyTransaction, testCase.event.getId());
@@ -1395,14 +1395,14 @@ class EventBookingManagerTest {
 
       replay(mockedObjects);
 
-      Long remainingPlacesAvailable = eventBookingManager.getPlacesAvailable(testEvent);
+      Integer remainingPlacesAvailable = eventBookingManager.getPlacesAvailable(testEvent);
       assertNull(remainingPlacesAvailable);
       verify(mockedObjects);
     }
 
     @ParameterizedTest(name = "{index} {3}")
     @MethodSource
-    void getPlacesAvailable_returnsCorrectCount(IsaacEventPageDTO testEvent, Long expectedPlacesAvailable, Map<BookingStatus, Map<Role, Long>> bookingStatusMap, String description)
+    void getPlacesAvailable_returnsCorrectCount(IsaacEventPageDTO testEvent, Integer expectedPlacesAvailable, Map<BookingStatus, Map<Role, Integer>> bookingStatusMap, String description)
         throws SegueDatabaseException {
       EventBookingManager eventBookingManager = buildEventBookingManager();
 
@@ -1410,58 +1410,58 @@ class EventBookingManagerTest {
           bookingStatusMap);
       replay(mockedObjects);
 
-      Long remainingPlacesAvailable = eventBookingManager.getPlacesAvailable(testEvent);
+      Integer remainingPlacesAvailable = eventBookingManager.getPlacesAvailable(testEvent);
       assertEquals(expectedPlacesAvailable, remainingPlacesAvailable, description);
       verify(mockedObjects);
     }
 
     private static Stream<Arguments> getPlacesAvailable_returnsCorrectCount() {
       return Stream.of(
-          Arguments.of(prepareIsaacEventPageDto(studentCSTags, 500, EventStatus.WAITING_LIST_ONLY), 499L,
+          Arguments.of(prepareIsaacEventPageDto(studentCSTags, 500, EventStatus.WAITING_LIST_ONLY), 499,
               testBookingStatusMap, "WAITING_LIST_ONLY student events should count confirmed student bookings"),
-          Arguments.of(prepareIsaacEventPageDto(studentCSTags, 500, EventStatus.OPEN), 389L, testBookingStatusMap,
+          Arguments.of(prepareIsaacEventPageDto(studentCSTags, 500, EventStatus.OPEN), 389, testBookingStatusMap,
               "OPEN student events should count student bookings that are confirmed, reserved or on the waiting list"),
-          Arguments.of(prepareIsaacEventPageDto(teacherCSTags, 500, EventStatus.WAITING_LIST_ONLY), 485L,
+          Arguments.of(prepareIsaacEventPageDto(teacherCSTags, 500, EventStatus.WAITING_LIST_ONLY), 485,
               testBookingStatusMap, "WAITING_LIST_ONLY standard events should count confirmed bookings for all roles"),
-          Arguments.of(prepareIsaacEventPageDto(teacherCSTags, 500, EventStatus.OPEN), 155L, testBookingStatusMap,
+          Arguments.of(prepareIsaacEventPageDto(teacherCSTags, 500, EventStatus.OPEN), 155, testBookingStatusMap,
               "OPEN standard events should count bookings that are confirmed, reserved or on the waiting list for all roles"),
-          Arguments.of(prepareIsaacEventPageDto(studentCSTags, 10, EventStatus.OPEN), 0L, smallStudentBookingStatusMap,
+          Arguments.of(prepareIsaacEventPageDto(studentCSTags, 10, EventStatus.OPEN), 0, smallStudentBookingStatusMap,
               "Student events should return a minimum remaining places available of zero"),
-          Arguments.of(prepareIsaacEventPageDto(teacherCSTags, 10, EventStatus.OPEN), 0L, smallTeacherBookingStatusMap,
+          Arguments.of(prepareIsaacEventPageDto(teacherCSTags, 10, EventStatus.OPEN), 0, smallTeacherBookingStatusMap,
               "Standard events should return a minimum remaining places available of zero"),
-          Arguments.of(prepareIsaacEventPageDto(studentCSTags, 10, EventStatus.WAITING_LIST_ONLY), 10L, Map.of(),
+          Arguments.of(prepareIsaacEventPageDto(studentCSTags, 10, EventStatus.WAITING_LIST_ONLY), 10, Map.of(),
               "WAITING_LIST_ONLY student events should handle an empty map"),
-          Arguments.of(prepareIsaacEventPageDto(studentCSTags, 10, EventStatus.OPEN), 10L, Map.of(),
+          Arguments.of(prepareIsaacEventPageDto(studentCSTags, 10, EventStatus.OPEN), 10, Map.of(),
               "OPEN student events should handle an empty map"),
-          Arguments.of(prepareIsaacEventPageDto(teacherCSTags, 10, EventStatus.WAITING_LIST_ONLY), 10L, Map.of(),
+          Arguments.of(prepareIsaacEventPageDto(teacherCSTags, 10, EventStatus.WAITING_LIST_ONLY), 10, Map.of(),
               "WAITING_LIST_ONLY standard events should handle an empty map"),
-          Arguments.of(prepareIsaacEventPageDto(teacherCSTags, 10, EventStatus.OPEN), 10L, Map.of(),
+          Arguments.of(prepareIsaacEventPageDto(teacherCSTags, 10, EventStatus.OPEN), 10, Map.of(),
               "OPEN standard events should handle an empty map")
       );
     }
 
-    private static final Map<BookingStatus, Map<Role, Long>> testBookingStatusMap = Map.of(
+    private static final Map<BookingStatus, Map<Role, Integer>> testBookingStatusMap = Map.of(
         BookingStatus.CONFIRMED, Map.of(
-            Role.STUDENT, 1L, Role.TEACHER, 2L, Role.TUTOR, 4L, Role.EVENT_LEADER, 8L
+            Role.STUDENT, 1, Role.TEACHER, 2, Role.TUTOR, 4, Role.EVENT_LEADER, 8
         ),
         BookingStatus.RESERVED, Map.of(
-            Role.STUDENT, 10L, Role.TEACHER, 20L
+            Role.STUDENT, 10, Role.TEACHER, 20
         ),
         BookingStatus.WAITING_LIST, Map.of(
-            Role.STUDENT, 100L, Role.TEACHER, 200L
+            Role.STUDENT, 100, Role.TEACHER, 200
         ),
         BookingStatus.CANCELLED, Map.of(
-            Role.STUDENT, 1000L
+            Role.STUDENT, 1000
         )
     );
 
-    private static final Map<BookingStatus, Map<Role, Long>> smallStudentBookingStatusMap =
-        Map.of(BookingStatus.CONFIRMED, Map.of(Role.STUDENT, 15L), BookingStatus.WAITING_LIST,
-            Map.of(Role.STUDENT, 5L));
+    private static final Map<BookingStatus, Map<Role, Integer>> smallStudentBookingStatusMap =
+        Map.of(BookingStatus.CONFIRMED, Map.of(Role.STUDENT, 15), BookingStatus.WAITING_LIST,
+            Map.of(Role.STUDENT, 5));
 
-    private static final Map<BookingStatus, Map<Role, Long>> smallTeacherBookingStatusMap =
-        Map.of(BookingStatus.CONFIRMED, Map.of(Role.TEACHER, 15L), BookingStatus.WAITING_LIST,
-            Map.of(Role.TEACHER, 5L));
+    private static final Map<BookingStatus, Map<Role, Integer>> smallTeacherBookingStatusMap =
+        Map.of(BookingStatus.CONFIRMED, Map.of(Role.TEACHER, 15), BookingStatus.WAITING_LIST,
+            Map.of(Role.TEACHER, 5));
 
   }
 
@@ -1618,8 +1618,8 @@ class EventBookingManagerTest {
     expectLastCall().once();
   }
 
-  private static Map<BookingStatus, Map<Role, Long>> generatePlacesAvailableMap() {
-    Map<BookingStatus, Map<Role, Long>> placesAvailableMap = Maps.newHashMap();
+  private static Map<BookingStatus, Map<Role, Integer>> generatePlacesAvailableMap() {
+    Map<BookingStatus, Map<Role, Integer>> placesAvailableMap = Maps.newHashMap();
     placesAvailableMap.put(BookingStatus.CANCELLED, Maps.newHashMap());
     placesAvailableMap.put(BookingStatus.WAITING_LIST, Maps.newHashMap());
     placesAvailableMap.put(BookingStatus.CONFIRMED, Maps.newHashMap());

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookingsTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookingsTest.java
@@ -53,40 +53,40 @@ class PgEventBookingsTest {
     expect(dummyResultSet.next()).andReturn(true).once();
     expect(dummyResultSet.getString("status")).andReturn("CONFIRMED").once();
     expect(dummyResultSet.getString("role")).andReturn("STUDENT").once();
-    expect(dummyResultSet.getLong("count")).andReturn(20L).once();
+    expect(dummyResultSet.getInt("count")).andReturn(20).once();
 
     expect(dummyResultSet.next()).andReturn(true).once();
     expect(dummyResultSet.getString("status")).andReturn("CONFIRMED").once();
     expect(dummyResultSet.getString("role")).andReturn("TEACHER").once();
-    expect(dummyResultSet.getLong("count")).andReturn(4L).once();
+    expect(dummyResultSet.getInt("count")).andReturn(4).once();
 
     expect(dummyResultSet.next()).andReturn(true).once();
     expect(dummyResultSet.getString("status")).andReturn("WAITING_LIST").once();
     expect(dummyResultSet.getString("role")).andReturn("STUDENT").once();
-    expect(dummyResultSet.getLong("count")).andReturn(10L).once();
+    expect(dummyResultSet.getInt("count")).andReturn(10).once();
 
     expect(dummyResultSet.next()).andReturn(true).once();
     expect(dummyResultSet.getString("status")).andReturn("CANCELLED").once();
     expect(dummyResultSet.getString("role")).andReturn("TEACHER").once();
-    expect(dummyResultSet.getLong("count")).andReturn(2L).once();
+    expect(dummyResultSet.getInt("count")).andReturn(2).once();
 
     expect(dummyResultSet.next()).andReturn(false).once();
     dummyResultSet.close();
     dummyConnection.close();
 
     // Create expected status count
-    Map<BookingStatus, Map<Role, Long>> expectedStatusCounts = new HashMap<BookingStatus, Map<Role, Long>>() {{
-        put(BookingStatus.CONFIRMED, new HashMap<Role, Long>() {{
-            put(Role.STUDENT, 20L);
-            put(Role.TEACHER, 4L);
+    Map<BookingStatus, Map<Role, Integer>> expectedStatusCounts = new HashMap<>() {{
+        put(BookingStatus.CONFIRMED, new HashMap<>() {{
+            put(Role.STUDENT, 20);
+            put(Role.TEACHER, 4);
           }
         });
-        put(BookingStatus.WAITING_LIST, new HashMap<Role, Long>() {{
-            put(Role.STUDENT, 10L);
+        put(BookingStatus.WAITING_LIST, new HashMap<>() {{
+            put(Role.STUDENT, 10);
           }
         });
-        put(BookingStatus.CANCELLED, new HashMap<Role, Long>() {{
-            put(Role.TEACHER, 2L);
+        put(BookingStatus.CANCELLED, new HashMap<>() {{
+            put(Role.TEACHER, 2);
           }
         });
       }};
@@ -95,7 +95,7 @@ class PgEventBookingsTest {
     Object[] mockedObjects = {dummyPostgresSqlDb, dummyConnection, dummyPreparedStatement, dummyResultSet};
     replay(mockedObjects);
     PgEventBookings pgEventBookings = this.buildPgEventBookings();
-    Map<BookingStatus, Map<Role, Long>> actualStatusCounts =
+    Map<BookingStatus, Map<Role, Integer>> actualStatusCounts =
         pgEventBookings.getEventBookingStatusCounts("someEventId", true);
     assertEquals(expectedStatusCounts, actualStatusCounts, "Every row should be represented in the result");
     verify(mockedObjects);


### PR DESCRIPTION
[Ticket](https://github.com/isaaccomputerscience/isaac-cs-issues/issues/370)
The issue appears to have been a check that was not applied to student events, so that has now been added. Additionally, the relevant function has been refactored to comply with the recommended Cognitive Complexity limits.
The filter for which roles should be subject to capacity limits on student events has been changed to only count students (and tutors) instead of only ignoring teachers, allowing roles above teacher to be handled similarly in the event they try to book.
Some additional unit tests for the capacity calculations have been added and some broader unit tests for the booking functionality have been brought over from #182 to check that the refactor did not impact functionaity.