### PR TITLE
Robert/375 enumeration registration rework

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -202,6 +202,7 @@ public final class Constants {
   public static final String EMAIL_TEMPLATE_TOKEN_EVENT_DETAILS = "event.emailEventDetails";
   public static final String EMAIL_TEMPLATE_TOKEN_EVENT = "event";
   public static final String EMAIL_TEMPLATE_TOKEN_EVENT_URL = "eventURL";
+  public static final String EMAIL_TEMPLATE_TOKEN_PROVIDER = "provider";
 
   // Email Template Ids
   public static final String EMAIL_TEMPLATE_ID_EVENT_BOOKING_CONFIRMED = "email-event-booking-confirmed";
@@ -233,6 +234,7 @@ public final class Constants {
   public static final String EXCEPTION_MESSAGE_NOT_EVENT = "Content object is not an event page.";
   public static final String EXCEPTION_MESSAGE_CANNOT_CREATE_BOOKING_DTO =
       "Unable to create event booking DTO from DO.";
+  public static final String EXCEPTION_MESSAGE_INVALID_EMAIL = "The email address provided is invalid.";
 
   /**
    * Private constructor to prevent this class being created.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -19,9 +19,11 @@ package uk.ac.cam.cl.dtg.isaac.api;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.SEGUE_SERVER_LOG_TYPES;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import uk.ac.cam.cl.dtg.segue.api.Constants.LogType;
 
 /**
@@ -174,13 +176,10 @@ public final class Constants {
   public static final Set<String> ISAAC_CLIENT_LOG_TYPES =
       Arrays.stream(IsaacClientLogType.values()).map(IsaacClientLogType::name).collect(Collectors.toSet());
 
-  public static final Set<String> ALL_ACCEPTED_LOG_TYPES = new HashSet<>() {
-    {
-      addAll(SEGUE_SERVER_LOG_TYPES);
-      addAll(ISAAC_SERVER_LOG_TYPES);
-      addAll(ISAAC_CLIENT_LOG_TYPES);
-    }
-  };
+  public static final Set<String> ALL_ACCEPTED_LOG_TYPES =
+      Stream.of(SEGUE_SERVER_LOG_TYPES, ISAAC_SERVER_LOG_TYPES, ISAAC_CLIENT_LOG_TYPES)
+          .flatMap(Collection::stream)
+          .collect(Collectors.toCollection(HashSet::new));
 
   public enum IsaacUserPreferences {
     BETA_FEATURE, EXAM_BOARD, PROGRAMMING_LANGUAGE, BOOLEAN_NOTATION, DISPLAY_SETTING

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -18,7 +18,6 @@ package uk.ac.cam.cl.dtg.isaac.api;
 
 import static uk.ac.cam.cl.dtg.segue.api.Constants.SEGUE_SERVER_LOG_TYPES;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -49,7 +48,7 @@ public final class Constants {
   public static final String HIDE_FROM_FILTER_TAG = "nofilter";
   public static final String RELATED_CONTENT_FIELDNAME = "relatedContent";
 
-  public static final Set<String> SITE_WIDE_SEARCH_VALID_DOC_TYPES = ImmutableSet.of(
+  public static final Set<String> SITE_WIDE_SEARCH_VALID_DOC_TYPES = Set.of(
       QUESTION_TYPE, CONCEPT_TYPE, TOPIC_SUMMARY_PAGE_TYPE, PAGE_TYPE, EVENT_TYPE);
 
   public static final int NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES = 2;
@@ -175,7 +174,7 @@ public final class Constants {
   public static final Set<String> ISAAC_CLIENT_LOG_TYPES =
       Arrays.stream(IsaacClientLogType.values()).map(IsaacClientLogType::name).collect(Collectors.toSet());
 
-  public static final Set<String> ALL_ACCEPTED_LOG_TYPES = new HashSet<String>() {
+  public static final Set<String> ALL_ACCEPTED_LOG_TYPES = new HashSet<>() {
     {
       addAll(SEGUE_SERVER_LOG_TYPES);
       addAll(ISAAC_SERVER_LOG_TYPES);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/RegisteredUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/RegisteredUser.java
@@ -331,9 +331,9 @@ public class RegisteredUser extends AbstractSegueUser {
   }
 
   /**
-   * Gets the resetExpiry.
+   * Gets the email verification token.
    *
-   * @return the resetExpiry
+   * @return the email verification token
    */
   public final String getEmailVerificationToken() {
     return this.emailVerificationToken;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -262,15 +262,14 @@ public class UsersFacade extends AbstractSegueFacade {
         // which has not made any other authenticated/logged request to Isaac beforehand.
         // This _might_ be suspicious, and this logging will help establish that.
         if (request.getSession() == null || request.getSession().getAttribute(ANONYMOUS_USER) == null) {
-          log.error(String.format("Registration attempt from (%s) for (%s) without corresponding anonymous user!",
-              ipAddress, sanitiseExternalLogValue(registeredUser.getEmail())));
+          log.error("Registration attempt from ({}) for ({}) without corresponding anonymous user!",
+              ipAddress, sanitiseExternalLogValue(registeredUser.getEmail()));
         }
 
-        return userManager.createUserObjectAndLogIn(request, response, registeredUser, newPassword, userPreferences,
-            registeredUserContexts);
+        return userManager.createNewUser(request, registeredUser, newPassword, userPreferences, registeredUserContexts);
       } catch (SegueResourceMisuseException e) {
-        log.error(String.format("Blocked a registration attempt by (%s) after misuse limit hit!",
-            RequestIpExtractor.getClientIpAddr(request)));
+        log.error("Blocked a registration attempt by ({}) after misuse limit hit!",
+            RequestIpExtractor.getClientIpAddr(request));
         return SegueErrorResponse.getRateThrottledResponse(
             "Too many registration requests. Please try again later or contact us!");
       }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -729,7 +729,7 @@ public class UsersFacade extends AbstractSegueFacade {
       RegisteredUser targetUser = userManager.findUserByEmail(userEmail);
       if (targetUser == null) {
         // As this endpoint does not require authentication, do not expose whether the requested user exists
-        log.warn("A role change request was made for unknown user: {}", userEmail);
+        log.warn("A role change request was made for unknown user: {}", sanitiseExternalLogValue(userEmail));
         return Response.ok().build();
       }
 
@@ -751,7 +751,7 @@ public class UsersFacade extends AbstractSegueFacade {
       // This exception is thrown after we have already checked whether a user exists for the provided email address,
       // so something has gone very wrong
       log.error("Could not find user with email address ({}) to set teacherPending flag."
-              + " This should have already been caught.", userEmail);
+              + " This should have already been caught.", sanitiseExternalLogValue(userEmail));
       return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
           "An error occurred while trying to set the role change request flag.").toResponse();
     } catch (SegueDatabaseException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -733,7 +733,7 @@ public class UsersFacade extends AbstractSegueFacade {
         return Response.ok().build();
       }
 
-      if (targetUser.getTeacherPending() == Boolean.TRUE) {
+      if (Boolean.TRUE.equals(targetUser.getTeacherPending())) {
         return new SegueErrorResponse(
             Status.BAD_REQUEST, "You have already submitted a teacher upgrade request.").toResponse();
       }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -1724,7 +1724,7 @@ public class UserAccountManager implements IUserAccountManager {
    * @return user or null if we cannot find it.
    * @throws SegueDatabaseException - If there is an internal database error.
    */
-  private RegisteredUser findUserByEmail(final String email) throws SegueDatabaseException {
+  public RegisteredUser findUserByEmail(final String email) throws SegueDatabaseException {
     if (null == email) {
       return null;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -1841,7 +1841,7 @@ public class UserAccountManager implements IUserAccountManager {
   public static boolean isEmailValid(final String email) {
     return email != null
         && !email.isEmpty()
-        && email.matches(".*(?:@.+\\.[^.]+|-(facebook|google|twitter))$")
+        && email.matches("^.+(?:@(?:[a-zA-Z0-9-]{1,63}+\\.)++[a-zA-Z]{1,63}+|-(?:facebook|google|twitter))$")
         && EMAIL_PERMITTED_CHARS_REGEX.matcher(email).matches()
         && !EMAIL_CONSECUTIVE_FULL_STOP_REGEX.matcher(email).find();
   }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -98,7 +98,6 @@ import uk.ac.cam.cl.dtg.segue.auth.exceptions.AuthenticatorSecurityException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.CodeExchangeException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.CrossSiteRequestForgeryException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.DuplicateAccountException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.FailedToHashPasswordException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.IncorrectCredentialsProvidedException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.InvalidNameException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.InvalidPasswordException;
@@ -418,10 +417,6 @@ public class UserAccountManager implements IUserAccountManager {
     } catch (InvalidPasswordException e) {
       log.warn("Invalid password exception occurred during registration!");
       return new SegueErrorResponse(Response.Status.BAD_REQUEST, e.getMessage()).toResponse();
-    } catch (FailedToHashPasswordException e) {
-      log.error("Failed to hash password during user registration!");
-      return new SegueErrorResponse(Response.Status.INTERNAL_SERVER_ERROR,
-          "Unable to set a password.").toResponse();
     } catch (MissingRequiredFieldException e) {
       log.warn("Missing field during update operation: {}", e.getMessage());
       return new SegueErrorResponse(Response.Status.BAD_REQUEST, "You are missing a required field. "
@@ -429,6 +424,8 @@ public class UserAccountManager implements IUserAccountManager {
     } catch (DuplicateAccountException e) {
       log.warn("Duplicate account registration attempt for ({})",
           sanitiseExternalLogValue(userObjectFromClient.getEmail()));
+      // For security reasons, an otherwise-valid request for existing account should return the same response as for
+      // a new one
       return Response.ok().build();
     } catch (SegueDatabaseException e) {
       String errorMsg = "Unable to set a password, due to an internal database error.";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidEmailException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidEmailException.java
@@ -1,0 +1,17 @@
+package uk.ac.cam.cl.dtg.segue.auth.exceptions;
+
+/**
+ * An exception which indicates the email address provided by the user is not valid.
+ */
+public class InvalidEmailException extends Exception {
+
+  /**
+   * An exception which indicates the email address provided by the user is not valid.
+   *
+   * @param message - message to add
+   */
+
+  public InvalidEmailException(final String message) {
+    super(message);
+  }
+}

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManagerTest.java
@@ -162,9 +162,12 @@ class UserAccountManagerTest {
         Arguments.of(false, " "), // Only whitespace is not valid
         Arguments.of(false, "test.email@testcom"), // Email must have at least one . after the @
         Arguments.of(false, "testemailtest.com"), // Standard email must include an @
-        Arguments.of(false, "testemail@test."), // Email must have be at least character after the last .
+        Arguments.of(false, "testemail@test."), // Email must have at least character after the last .
+        Arguments.of(false, "testemail@test.test."), // Email must have at least character after the last .
         Arguments.of(false, "testemail@.com"), // Email must have at least one character between the @ and the last .
+        Arguments.of(false, "testemail@.test.com"), // Email must have at least one character between the @ and the last .
         Arguments.of(false, "testemail@test..com"), // Email cannot contain consecutive full stops
+        Arguments.of(false, "@test.com"), // Empty local-part is not permitted
         // Other special characters are not permitted
         Arguments.of(false, "test\"email@test.com"),
         Arguments.of(false, "test(email@test.com"),

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManagerTest.java
@@ -643,6 +643,161 @@ class UserAccountManagerTest {
     }
 
     @Test
+    void createNewUser_invalidEmailAddress_returnsBadRequest() throws InvalidPasswordException {
+      String newUserEmailAddress = "badEmailAddress";
+      HttpServletRequest mockRequest = createMock(HttpServletRequest.class);
+      RegisteredUser userObjectFromFrontEnd = prepareRegisteredUser(newUserEmailAddress);
+      String newUserPassword = "Password123!";
+      Map<String, Map<String, Boolean>> newUserPreferences = Map.of();
+      List<UserContext> newUserContexts = List.of();
+
+      RegisteredUserDTO temporaryUserDTO = new RegisteredUserDTO();
+      RegisteredUser sanitisedUserObject = prepareRegisteredUser(newUserEmailAddress);
+      expect(userMapper.map(userObjectFromFrontEnd)).andReturn(temporaryUserDTO);
+      expect(userMapper.map(temporaryUserDTO)).andReturn(sanitisedUserObject);
+
+      segueLocalAuthenticator.ensureValidPassword(newUserPassword);
+
+      replay(userMapper, segueLocalAuthenticator, database, emailManager);
+
+      try {
+        try (Response response = userAccountManager.createNewUser(mockRequest, userObjectFromFrontEnd, newUserPassword,
+            newUserPreferences, newUserContexts)) {
+          assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+          assertEquals("The email address provided is invalid.",
+              response.readEntity(SegueErrorResponse.class).getErrorMessage());
+        }
+      } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+        fail("Unexpected exception from method under test");
+      }
+    }
+
+    @Test
+    void createNewUser_emptyPassword_returnsBadRequest() throws InvalidPasswordException {
+      String newUserEmailAddress = "exampleAddress@test.com";
+      HttpServletRequest mockRequest = createMock(HttpServletRequest.class);
+      RegisteredUser userObjectFromFrontEnd = prepareRegisteredUser(newUserEmailAddress);
+      String newUserPassword = "";
+      Map<String, Map<String, Boolean>> newUserPreferences = Map.of();
+      List<UserContext> newUserContexts = List.of();
+
+      RegisteredUserDTO temporaryUserDTO = new RegisteredUserDTO();
+      RegisteredUser sanitisedUserObject = prepareRegisteredUser(newUserEmailAddress);
+      expect(userMapper.map(userObjectFromFrontEnd)).andReturn(temporaryUserDTO);
+      expect(userMapper.map(temporaryUserDTO)).andReturn(sanitisedUserObject);
+
+      segueLocalAuthenticator.ensureValidPassword(newUserPassword);
+      expectLastCall().andThrow(new InvalidPasswordException("Invalid password"));
+
+      replay(userMapper, segueLocalAuthenticator, database, emailManager);
+
+      try {
+        try (Response response = userAccountManager.createNewUser(mockRequest, userObjectFromFrontEnd, newUserPassword,
+            newUserPreferences, newUserContexts)) {
+          assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+          assertEquals(
+              "You are missing a required field. Please make sure you have specified all mandatory fields in your response.",
+              response.readEntity(SegueErrorResponse.class).getErrorMessage());
+        }
+      } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+        fail("Unexpected exception from method under test");
+      }
+    }
+
+    @Test
+    void createNewUser_emptyGivenName_returnsBadRequest() throws InvalidPasswordException {
+      String newUserEmailAddress = "exampleAddress@test.com";
+      HttpServletRequest mockRequest = createMock(HttpServletRequest.class);
+      RegisteredUser userObjectFromFrontEnd = prepareRegisteredUserEmptyGivenName(newUserEmailAddress);
+      String newUserPassword = "Password123!";
+      Map<String, Map<String, Boolean>> newUserPreferences = Map.of();
+      List<UserContext> newUserContexts = List.of();
+
+      RegisteredUserDTO temporaryUserDTO = new RegisteredUserDTO();
+      RegisteredUser sanitisedUserObject = prepareRegisteredUserEmptyGivenName(newUserEmailAddress);
+      expect(userMapper.map(userObjectFromFrontEnd)).andReturn(temporaryUserDTO);
+      expect(userMapper.map(temporaryUserDTO)).andReturn(sanitisedUserObject);
+
+      segueLocalAuthenticator.ensureValidPassword(newUserPassword);
+
+      replay(userMapper, segueLocalAuthenticator, database, emailManager);
+
+      try {
+        try (Response response = userAccountManager.createNewUser(mockRequest, userObjectFromFrontEnd, newUserPassword,
+            newUserPreferences, newUserContexts)) {
+          assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+          assertEquals(
+              "You are missing a required field. Please make sure you have specified all mandatory fields in your response.",
+              response.readEntity(SegueErrorResponse.class).getErrorMessage());
+        }
+      } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+        fail("Unexpected exception from method under test");
+      }
+    }
+
+    @Test
+    void createNewUser_emptyFamilyName_returnsBadRequest() throws InvalidPasswordException {
+      String newUserEmailAddress = "exampleAddress@test.com";
+      HttpServletRequest mockRequest = createMock(HttpServletRequest.class);
+      RegisteredUser userObjectFromFrontEnd = prepareRegisteredUserEmptyFamilyName(newUserEmailAddress);
+      String newUserPassword = "Password123!";
+      Map<String, Map<String, Boolean>> newUserPreferences = Map.of();
+      List<UserContext> newUserContexts = List.of();
+
+      RegisteredUserDTO temporaryUserDTO = new RegisteredUserDTO();
+      RegisteredUser sanitisedUserObject = prepareRegisteredUserEmptyFamilyName(newUserEmailAddress);
+      expect(userMapper.map(userObjectFromFrontEnd)).andReturn(temporaryUserDTO);
+      expect(userMapper.map(temporaryUserDTO)).andReturn(sanitisedUserObject);
+
+      segueLocalAuthenticator.ensureValidPassword(newUserPassword);
+
+      replay(userMapper, segueLocalAuthenticator, database, emailManager);
+
+      try {
+        try (Response response = userAccountManager.createNewUser(mockRequest, userObjectFromFrontEnd, newUserPassword,
+            newUserPreferences, newUserContexts)) {
+          assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+          assertEquals(
+              "You are missing a required field. Please make sure you have specified all mandatory fields in your response.",
+              response.readEntity(SegueErrorResponse.class).getErrorMessage());
+        }
+      } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+        fail("Unexpected exception from method under test");
+      }
+    }
+
+    @Test
+    void createNewUser_emptyEmailAddress_returnsBadRequest() throws InvalidPasswordException {
+      String newUserEmailAddress = "";
+      HttpServletRequest mockRequest = createMock(HttpServletRequest.class);
+      RegisteredUser userObjectFromFrontEnd = prepareRegisteredUser(newUserEmailAddress);
+      String newUserPassword = "Password123!";
+      Map<String, Map<String, Boolean>> newUserPreferences = Map.of();
+      List<UserContext> newUserContexts = List.of();
+
+      RegisteredUserDTO temporaryUserDTO = new RegisteredUserDTO();
+      RegisteredUser sanitisedUserObject = prepareRegisteredUser(newUserEmailAddress);
+      expect(userMapper.map(userObjectFromFrontEnd)).andReturn(temporaryUserDTO);
+      expect(userMapper.map(temporaryUserDTO)).andReturn(sanitisedUserObject);
+
+      segueLocalAuthenticator.ensureValidPassword(newUserPassword);
+
+      replay(userMapper, segueLocalAuthenticator, database, emailManager);
+
+      try {
+        try (Response response = userAccountManager.createNewUser(mockRequest, userObjectFromFrontEnd, newUserPassword,
+            newUserPreferences, newUserContexts)) {
+          assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+          assertEquals(
+              "You are missing a required field. Please make sure you have specified all mandatory fields in your response.",
+              response.readEntity(SegueErrorResponse.class).getErrorMessage());
+        }
+      } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+        fail("Unexpected exception from method under test");
+      }
+    }
+
+    @Test
     void createNewUser_isaacEmailAddress_returnsBadRequest() throws InvalidPasswordException, SegueDatabaseException {
       String newUserEmailAddress = "exampleAddress@isaaccomputerscience.org";
       HttpServletRequest mockRequest = createMock(HttpServletRequest.class);
@@ -720,12 +875,28 @@ class UserAccountManagerTest {
     private RegisteredUser prepareRegisteredUserInvalidGivenName(String newUserEmailAddress) {
       RegisteredUser registeredUser = new RegisteredUser();
       registeredUser.setEmail(newUserEmailAddress);
+      registeredUser.setGivenName("a^b");
+      registeredUser.setFamilyName("familyName");
+      return registeredUser;
+    }
+
+    private RegisteredUser prepareRegisteredUserEmptyGivenName(String newUserEmailAddress) {
+      RegisteredUser registeredUser = new RegisteredUser();
+      registeredUser.setEmail(newUserEmailAddress);
       registeredUser.setGivenName("");
       registeredUser.setFamilyName("familyName");
       return registeredUser;
     }
 
     private RegisteredUser prepareRegisteredUserInvalidFamilyName(String newUserEmailAddress) {
+      RegisteredUser registeredUser = new RegisteredUser();
+      registeredUser.setEmail(newUserEmailAddress);
+      registeredUser.setGivenName("givenName");
+      registeredUser.setFamilyName("a^b");
+      return registeredUser;
+    }
+
+    private RegisteredUser prepareRegisteredUserEmptyFamilyName(String newUserEmailAddress) {
       RegisteredUser registeredUser = new RegisteredUser();
       registeredUser.setEmail(newUserEmailAddress);
       registeredUser.setGivenName("givenName");


### PR DESCRIPTION
[Ticket](https://github.com/isaaccomputerscience/isaac-cs-issues/issues/375)
Modify registration process to:

- No longer automatically log in the new user
- Ensure the response returned to the front end is consistent between successful requests and ones that would have been valid if the email address was not already in use.
- Send an email to the target address if a duplicate registration attempt is made

Modify role change request endpoint to no longer require a logged-in user and to take a target email address instead, in order to be used with the updated registration process.
Update and expand tests accordingly.