### PR TITLE
Robert/402 account deletion fix

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -16,6 +16,7 @@
 
 package uk.ac.cam.cl.dtg.segue.dao.users;
 
+import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.NO_SESSION_TOKEN_RESERVED_VALUE;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.SchoolInfoStatus;
@@ -35,6 +36,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1070,7 +1072,8 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
     user.setSchoolOther(null); // Risk this contains something identifying!
 
     if (user.getDateOfBirth() != null) {
-      user.setDateOfBirth(user.getDateOfBirth().truncatedTo(ChronoUnit.MONTHS));
+      // Instant does not support operations with units larger than days so use LocalDateTime as intermediary
+      user.setDateOfBirth(LocalDateTime.from(user.getDateOfBirth()).truncatedTo(ChronoUnit.MONTHS).toInstant(UTC));
     }
 
     return user;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -36,7 +36,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1072,8 +1072,11 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
     user.setSchoolOther(null); // Risk this contains something identifying!
 
     if (user.getDateOfBirth() != null) {
-      // Instant does not support operations with units larger than days so use LocalDateTime as intermediary
-      user.setDateOfBirth(LocalDateTime.from(user.getDateOfBirth()).truncatedTo(ChronoUnit.MONTHS).toInstant(UTC));
+      // Instant does not support operations with larger units so use a more complex time class such as ZonedDateTime
+      // as an intermediary
+      ZonedDateTime dateAsZonedDate = ZonedDateTime.from(user.getDateOfBirth().atZone(UTC));
+      ZonedDateTime truncatedDate = dateAsZonedDate.truncatedTo(ChronoUnit.DAYS).withDayOfMonth(1);
+      user.setDateOfBirth(truncatedDate.toInstant());
     }
 
     return user;

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/ITConstants.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/ITConstants.java
@@ -44,6 +44,9 @@ public final class ITConstants {
   public static final String TEST_STUDENT_PASSWORD = "test1234";
   public static final long TEST_STUDENT_ID = 6L;
 
+  public static final String DELETION_TEST_STUDENT_EMAIL = "deletable-student@test.com";
+  public static final long DELETION_TEST_STUDENT_ID = 14L;
+
   // QuizFacade Additional Test Students
   // (1) Test Student is not in the QuizFacade assignment group and will make no free attempts
   // (2) Alice is the first member of QuizFacade assignment group, has no unassigned quiz attempts

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeIT.java
@@ -16,7 +16,6 @@
 
 package uk.ac.cam.cl.dtg.isaac.api;
 
-import static java.time.ZoneOffset.UTC;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -79,20 +78,14 @@ import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_TUTOR_EMAIL;
 import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_TUTOR_PASSWORD;
 import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.UNKNOWN_GROUP_ID;
 import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.UNKNOWN_QUIZ_ID;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.DEFAULT_DATE_FORMAT;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.HMAC_SALT;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.NUMBER_SECONDS_IN_FIVE_MINUTES;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -128,38 +121,6 @@ public class QuizFacadeIT extends IsaacIntegrationTest {
     this.quizFacade =
         new QuizFacade(properties, logManager, contentManager, quizManager, userAccountManager, userAssociationManager,
             groupManager, quizAssignmentManager, assignmentService, quizAttemptManager, quizQuestionManager);
-  }
-
-  /**
-   * As the integration tests do not currently support MFA login, we cannot use the normal login process and have to
-   * create cookies manually when testing admin accounts.
-   *
-   * @return a Cookie loaded with session information for the test admin user.
-   * @throws JsonProcessingException if the cookie serialisation fails
-   */
-  private Cookie createManualCookieForAdmin() throws JsonProcessingException {
-    DateTimeFormatter sessionDateFormat = DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT).withZone(UTC);
-    String userId = String.valueOf(TEST_ADMIN_ID);
-    String hmacKey = properties.getProperty(HMAC_SALT);
-    int sessionExpiryTimeInSeconds = NUMBER_SECONDS_IN_FIVE_MINUTES;
-
-    String sessionExpiryDate = sessionDateFormat.format(Instant.now().plusSeconds(sessionExpiryTimeInSeconds));
-
-    Map<String, String> sessionInformation =
-        userAuthenticationManager.prepareSessionInformation(userId, "0", sessionExpiryDate, hmacKey, null);
-    return userAuthenticationManager.createAuthCookie(sessionInformation, sessionExpiryTimeInSeconds);
-  }
-
-  private HttpServletRequest prepareAdminRequest() {
-    try {
-      Cookie adminSessionCookie = createManualCookieForAdmin();
-      HttpServletRequest adminRequest = createRequestWithCookies(new Cookie[] {adminSessionCookie});
-      replay(adminRequest);
-      return adminRequest;
-    } catch (JsonProcessingException e) {
-      fail(e);
-      return null;
-    }
   }
 
   protected HttpServletRequest prepareUserRequest(String userEmail, String userPassword) {

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/AdminFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/AdminFacadeIT.java
@@ -1,0 +1,113 @@
+package uk.ac.cam.cl.dtg.segue.api;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.DELETION_TEST_STUDENT_EMAIL;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.DELETION_TEST_STUDENT_ID;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_ADMIN_ID;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_NON_EXISTENT_USER_ID;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_TEACHER_EMAIL;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_TEACHER_PASSWORD;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import uk.ac.cam.cl.dtg.isaac.api.IsaacIntegrationTest;
+import uk.ac.cam.cl.dtg.isaac.dos.users.RegisteredUser;
+import uk.ac.cam.cl.dtg.segue.api.managers.IExternalAccountManager;
+import uk.ac.cam.cl.dtg.segue.api.managers.StatisticsManager;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.AdditionalAuthenticationRequiredException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.AuthenticationProviderMappingException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.IncorrectCredentialsProvidedException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.MFARequiredButNotConfiguredException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoCredentialsAvailableException;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.segue.scheduler.SegueJobService;
+
+class AdminFacadeIT extends IsaacIntegrationTest {
+  private AdminFacade adminFacade;
+
+  @BeforeEach
+  void beforeEach() {
+    // These three classes are only used in singular methods that we don't have tests for currently,
+    // so just mock them for now
+    StatisticsManager statisticsManager = createMock(StatisticsManager.class);
+    SegueJobService segueJobService = createMock(SegueJobService.class);
+    IExternalAccountManager externalAccountManager = createMock(IExternalAccountManager.class);
+    this.adminFacade = new AdminFacade(properties, userAccountManager, contentManager, logManager, statisticsManager,
+        userPreferenceManager, eventBookingManager, segueJobService, externalAccountManager, misuseMonitor,
+        emailManager);
+  }
+
+  @Nested
+  class DeleteUserAccount {
+    @Test
+    void piiIsCorrectlySanitised() throws SegueDatabaseException {
+      HttpServletRequest mockRequest = prepareAdminRequest();
+
+      try (Response response = adminFacade.deleteUserAccount(mockRequest, DELETION_TEST_STUDENT_ID)) {
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+      }
+
+      RegisteredUser deletedUser = pgUsers.getById(DELETION_TEST_STUDENT_ID, true);
+      assertNull(deletedUser.getFamilyName());
+      assertNull(deletedUser.getGivenName());
+      assertNotEquals(DELETION_TEST_STUDENT_EMAIL, deletedUser.getEmail());
+      assertNull(deletedUser.getEmailVerificationToken());
+      assertNull(deletedUser.getEmailToVerify());
+      assertNull(deletedUser.getSchoolOther());
+      assertNull(deletedUser.getDateOfBirth());
+    }
+
+    @Test
+    void nonAdminUser_returnsForbidden()
+        throws NoCredentialsAvailableException, SegueDatabaseException, AuthenticationProviderMappingException,
+        IncorrectCredentialsProvidedException, AdditionalAuthenticationRequiredException, InvalidKeySpecException,
+        NoSuchAlgorithmException, MFARequiredButNotConfiguredException {
+      LoginResult teacherLogin = loginAs(httpSession, TEST_TEACHER_EMAIL, TEST_TEACHER_PASSWORD);
+      HttpServletRequest mockRequest = createRequestWithCookies(new Cookie[]{teacherLogin.cookie});
+      replay(mockRequest);
+
+      try (Response response = adminFacade.deleteUserAccount(mockRequest, DELETION_TEST_STUDENT_ID)) {
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+      }
+    }
+
+    @Test
+    void anonymousUser_returnsUnauthorized() {
+      HttpServletRequest mockRequest = createNiceMock(HttpServletRequest.class);
+      replay(mockRequest);
+
+      try (Response response = adminFacade.deleteUserAccount(mockRequest, DELETION_TEST_STUDENT_ID)) {
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
+      }
+    }
+
+    @Test
+    void currentUserAsTarget_returnsBadRequest() {
+      HttpServletRequest mockRequest = prepareAdminRequest();
+
+      try (Response response = adminFacade.deleteUserAccount(mockRequest, TEST_ADMIN_ID)) {
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+      }
+    }
+
+    @Test
+    void unknownTargetUser_returnsNotFound() {
+      HttpServletRequest mockRequest = prepareAdminRequest();
+
+      try (Response response = adminFacade.deleteUserAccount(mockRequest, TEST_NON_EXISTENT_USER_ID)) {
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+      }
+    }
+  }
+}

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/AdminFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/AdminFacadeIT.java
@@ -18,6 +18,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Response;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -65,7 +66,7 @@ class AdminFacadeIT extends IsaacIntegrationTest {
       assertNull(deletedUser.getEmailVerificationToken());
       assertNull(deletedUser.getEmailToVerify());
       assertNull(deletedUser.getSchoolOther());
-      assertNull(deletedUser.getDateOfBirth());
+      assertEquals(Instant.parse("2010-04-01T00:00:00Z"), deletedUser.getDateOfBirth());
     }
 
     @Test

--- a/src/test/resources/test-postgres-rutherford-data-dump.sql
+++ b/src/test/resources/test-postgres-rutherford-data-dump.sql
@@ -34,6 +34,7 @@ COPY public.users (id, _id, family_name, given_name, email, role, date_of_birth,
 5	\N	Teacher	Test Teacher	test-teacher@test.com	TEACHER	\N	FEMALE	2019-08-01 12:51:05.416	\N	A Manually Entered School	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"all\\"}"}	2022-08-03 12:08:57.662	2022-08-03 12:08:57.741	VERIFIED	2022-08-17 10:54:22.763	test-teacher@test.com	m9A8P0VbpFQnzOdXOywx75lpaWSpssLmQ779ij2b5LQ	f	f
 12	\N	Tutor	Test Tutor	test-tutor@test.com	TUTOR	\N	\N	2022-12-12 14:42:02.974	\N	\N	{}	\N	2022-12-12 14:42:02.974	NOT_VERIFIED	2022-12-12 14:48:40.236	test-tutor@test.com	4V115j6oH0YctCgBYXclb3WUT8D2Bz4nIaoJCasCJs	f	f
 13	\N	Student	Pending Teacher	pending-teacher@test.com	STUDENT	\N	MALE	2019-08-01 12:51:39.981	110158	\N	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"all\\"}"}	2021-10-04 14:12:13.351	2021-10-04 14:12:13.384	VERIFIED	2022-08-09 10:55:06.592	pending-teacher@test.com	\N	f	t
+14	\N	Student	Deletable	deletable-student@test.com	STUDENT	\N	MALE	2019-08-01 12:51:39.981	110158	\N	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"ocr\\"}"}	2021-10-04 14:12:13.351	2021-10-04 14:12:13.384	VERIFIED	2022-08-09 10:55:06.592	deletable-student@test.com	ZMUU7NbjhUSawOClEzb1KPEMcUA93QCkxuGejMwmE	f	f
 \.
 
 
@@ -575,7 +576,7 @@ SELECT pg_catalog.setval('public.user_alerts_id_seq', 1, false);
 -- Name: users_id_seq; Type: SEQUENCE SET; Schema: public; Owner: rutherford
 --
 
-SELECT pg_catalog.setval('public.users_id_seq', 13, true);
+SELECT pg_catalog.setval('public.users_id_seq', 14, true);
 
 
 --

--- a/src/test/resources/test-postgres-rutherford-data-dump.sql
+++ b/src/test/resources/test-postgres-rutherford-data-dump.sql
@@ -34,7 +34,7 @@ COPY public.users (id, _id, family_name, given_name, email, role, date_of_birth,
 5	\N	Teacher	Test Teacher	test-teacher@test.com	TEACHER	\N	FEMALE	2019-08-01 12:51:05.416	\N	A Manually Entered School	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"all\\"}"}	2022-08-03 12:08:57.662	2022-08-03 12:08:57.741	VERIFIED	2022-08-17 10:54:22.763	test-teacher@test.com	m9A8P0VbpFQnzOdXOywx75lpaWSpssLmQ779ij2b5LQ	f	f
 12	\N	Tutor	Test Tutor	test-tutor@test.com	TUTOR	\N	\N	2022-12-12 14:42:02.974	\N	\N	{}	\N	2022-12-12 14:42:02.974	NOT_VERIFIED	2022-12-12 14:48:40.236	test-tutor@test.com	4V115j6oH0YctCgBYXclb3WUT8D2Bz4nIaoJCasCJs	f	f
 13	\N	Student	Pending Teacher	pending-teacher@test.com	STUDENT	\N	MALE	2019-08-01 12:51:39.981	110158	\N	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"all\\"}"}	2021-10-04 14:12:13.351	2021-10-04 14:12:13.384	VERIFIED	2022-08-09 10:55:06.592	pending-teacher@test.com	\N	f	t
-14	\N	Student	Deletable	deletable-student@test.com	STUDENT	\N	MALE	2019-08-01 12:51:39.981	110158	\N	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"ocr\\"}"}	2021-10-04 14:12:13.351	2021-10-04 14:12:13.384	VERIFIED	2022-08-09 10:55:06.592	deletable-student@test.com	ZMUU7NbjhUSawOClEzb1KPEMcUA93QCkxuGejMwmE	f	f
+14	\N	Student	Deletable	deletable-student@test.com	STUDENT	2010-04-17	MALE	2019-08-01 12:51:39.981	110158	\N	{"{\\"stage\\": \\"all\\", \\"examBoard\\": \\"ocr\\"}"}	2021-10-04 14:12:13.351	2021-10-04 14:12:13.384	VERIFIED	2022-08-09 10:55:06.592	deletable-student@test.com	ZMUU7NbjhUSawOClEzb1KPEMcUA93QCkxuGejMwmE	f	f
 \.
 
 


### PR DESCRIPTION
[Ticket](https://github.com/isaaccomputerscience/isaac-cs-issues/issues/402)
Instant does not support operations with units larger than days. The original method truncated dates to months for censorship purposes and was converted as-is to the newer time framework without accounting for this limitation.