### PR TITLE
[403]: Add explicit version dependency for Jackson datetime module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,11 @@
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Jose has reported some versioning inconsistency with the jackson datetime handling. As such, an explicit version dependency for the time module is being added to the pom file.