### PR TITLE
403 - teachers unable to create assignments with duedates

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentDTO.java
@@ -17,10 +17,10 @@
 package uk.ac.cam.cl.dtg.isaac.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.time.Instant;
 import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryDTO;
+
 
 /**
  * This class is the Data Transfer Object used to store Assignments in the isaac CMS.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentDTO.java
@@ -18,6 +18,8 @@ package uk.ac.cam.cl.dtg.isaac.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryDTO;
 
 /**
@@ -33,6 +35,9 @@ public class AssignmentDTO implements IAssignmentLike {
   private String notes;
   private UserSummaryDTO assignerSummary;
   private Instant creationDate;
+
+  // dueDate is not read correctly as an epoch by the jackson converter, this forces conversion
+  @JsonDeserialize(converter = LongToInstantConverter.class)
   private Instant dueDate;
   private Instant scheduledStartDate;
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LongToInstantConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LongToInstantConverter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.util.StdConverter;
 import java.time.Instant;
 
 public class LongToInstantConverter extends StdConverter<Long, Instant> {
+  @Override
   public Instant convert(final Long value) {
     return Instant.ofEpochMilli(value);
   }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LongToInstantConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LongToInstantConverter.java
@@ -1,7 +1,6 @@
 package uk.ac.cam.cl.dtg.isaac.dto;
 
 import com.fasterxml.jackson.databind.util.StdConverter;
-
 import java.time.Instant;
 
 public class LongToInstantConverter extends StdConverter<Long, Instant> {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LongToInstantConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LongToInstantConverter.java
@@ -1,0 +1,11 @@
+package uk.ac.cam.cl.dtg.isaac.dto;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+
+import java.time.Instant;
+
+public class LongToInstantConverter extends StdConverter<Long, Instant> {
+    public Instant convert(final Long value) {
+        return Instant.ofEpochMilli(value);
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LongToInstantConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LongToInstantConverter.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.util.StdConverter;
 import java.time.Instant;
 
 public class LongToInstantConverter extends StdConverter<Long, Instant> {
-    public Instant convert(final Long value) {
-        return Instant.ofEpochMilli(value);
-    }
+  public Instant convert(final Long value) {
+    return Instant.ofEpochMilli(value);
+  }
 }


### PR DESCRIPTION
For some reason the jackson objectmapper is failing to recognise the duedate as an epoch, even though the jsr310 module is loaded and the same behaviour works OK elsewhere in the codebase.
Explicitly converted the date and created a converter so the same annotation can be used elsewhere if the same behaviour occurs.

https://stackoverflow.com/questions/45762857/deserialize-millisecond-timestamp-to-java-time-instant

This discussion suggests that this behaviour shouldn't happen when nanosecond timestamps are turned off, not sure why it's not happening correctly here.