### PR TITLE
[421]: Resolve errors with logic question answer checks

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IValidator.java
@@ -92,6 +92,7 @@ public interface IValidator {
    * @return the response JSON, as a HashMap
    * @throws IOException - on failure to communicate with the external validator
    */
+  @SuppressWarnings("unchecked")
   default HashMap<String, Object> getResponseFromExternalValidator(final String externalValidatorUrl,
                                                                    final Map<String, String> requestBody)
       throws IOException {
@@ -103,21 +104,17 @@ public interface IValidator {
     g.close();
     String requestString = sw.toString();
 
-    HttpResponse httpResponse;
     try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
       HttpPost httpPost = new HttpPost(externalValidatorUrl);
 
       httpPost.setEntity(new StringEntity(requestString, "UTF-8"));
       httpPost.addHeader("Content-Type", "application/json");
 
-      httpResponse = httpClient.execute(httpPost);
+      HttpResponse httpResponse = httpClient.execute(httpPost);
+      HttpEntity responseEntity = httpResponse.getEntity();
+      String responseString = EntityUtils.toString(responseEntity);
+      return mapper.readValue(responseString, HashMap.class);
     }
-
-    HttpEntity responseEntity = httpResponse.getEntity();
-    String responseString = EntityUtils.toString(responseEntity);
-    HashMap<String, Object> response = mapper.readValue(responseString, HashMap.class);
-
-    return response;
   }
 
   /**


### PR DESCRIPTION
[Ticket](https://github.com/isaaccomputerscience/isaac-cs-issues/issues/421)
The checking of symbolic logic answers is handled by its own service, hosted in a separate container to the main api. Debugging of the answer validation process suggests that the answer is successfully received and processed by this validation service but the result is sometimes failing to make it back to the api.
As the http handling is wrapped in a try-with-resources block, it is possible that the connection is sometimes being incorrectly auto-closed before the return message is received.
As such, some code has been reorganised to try and resolve this behaviour. Due to inconsistency in occurrence of the issue, I can't guarantee that it's fixed, but I've tested in manually enough times without error to be reasonably confident.