### PR TITLE
conditionally don't check coverage for dependabot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Test with Maven
       run: mvn -B verify --file pom.xml
     - name: Add coverage to PR
+      if: github.actor != 'dependabot[bot]'
       id: jacoco
       uses: madrapps/jacoco-report@v1.6.1
       with:


### PR DESCRIPTION
There's a permissions issue preventing dependabot PRs from writing coverage details to PRs. I've set the workflow to skip coverage on dependabot PRs.
