### PR TITLE
604/shav-adding-fields-for-competition-entry-tracking

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -1011,8 +1011,10 @@ public class EventsFacade extends AbstractIsaacFacade {
       additionalInformation.put("submissionURL", entryDTO.getSubmissionURL());
       additionalInformation.put("groupName", entryDTO.getGroupName());
       additionalInformation.put("teacherName", reservingUser.getGivenName() + " " + reservingUser.getFamilyName());
+      additionalInformation.put("teacherEmail", reservingUser.getEmail());
       additionalInformation.put("teacherId", reservingUser.getId().toString());
       additionalInformation.put("school", reservingUser.getSchoolId());
+      additionalInformation.put("schoolName", reservingUser.getSchoolOther());
 
       // Tutors cannot yet manage event bookings for their tutees, so shouldn't be added to this list
       if (!Arrays.asList(Role.TEACHER, Role.EVENT_LEADER, Role.EVENT_MANAGER, Role.ADMIN)


### PR DESCRIPTION
Description:
This PR addresses the need to include the teacher's email address and school name in the competition entry data export. These additions will enhance the STEM team's ability to manage and track competition entries more effectively.
Key changes:
- Added teacherEmail to additionalInformation using reservingUser.getEmail()
- Included schoolName in additionalInformation using reservingUser.getSchoolOther()
- Updated the existing SQL query to incorporate these new fields

These modifications ensure that all necessary information is captured and can be exported for the STEM team's regular review of competition entries.

Ticket: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/604

Media attachement(s):

**Screenshot:** I've attached a screenshot showing the new fields (teacher email and school name) successfully pulled through in the local database.
![Screenshot 2025-02-24 at 15 14 53](https://github.com/user-attachments/assets/70b18839-7741-4b7e-aaf9-6ed3170cd733)


**CSV file:** I've included a `CSV` file containing local data of competition entries using the updated SQL query. This demonstrates that the new fields are correctly integrated and exported.

[local_competition_data.csv](https://github.com/user-attachments/files/18945421/local_competition_data.csv)

These attachments provide visual confirmation of the successful implementation and can be used for verification purposes.