### PR TITLE
Updated Index logic

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java
@@ -58,12 +58,12 @@ class SchoolIndexer {
     Instant fileLastModified = Instant.ofEpochMilli(f.lastModified());
     Instant indexLastModified;
     try {
-        indexLastModified = Instant.ofEpochMilli(
-            Long.parseLong(schoolsReader.getDataLastModifiedDate())
-        );
+      indexLastModified = Instant.ofEpochMilli(
+          Long.parseLong(schoolsReader.getDataLastModifiedDate())
+      );
     } catch (NumberFormatException e) {
-        log.error("Invalid data format for last modified date: {}", schoolsReader.getDataLastModifiedDate(), e);
-        throw new UnableToIndexSchoolsException("Failed to parse last modified date from school data.", e);
+      log.error("Invalid data format for last modified date: {}", schoolsReader.getDataLastModifiedDate(), e);
+      throw new UnableToIndexSchoolsException("Failed to parse last modified date from school data.", e);
     }
 
     if (indexLastModified.isAfter(fileLastModified)) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java
@@ -56,9 +56,15 @@ class SchoolIndexer {
     SchoolListReader schoolsReader = new SchoolListReader(es);
 
     Instant fileLastModified = Instant.ofEpochMilli(f.lastModified());
-    Instant indexLastModified = Instant.ofEpochMilli(
-        Long.parseLong(schoolsReader.getDataLastModifiedDate())
-    );
+    Instant indexLastModified;
+    try {
+        indexLastModified = Instant.ofEpochMilli(
+            Long.parseLong(schoolsReader.getDataLastModifiedDate())
+        );
+    } catch (NumberFormatException e) {
+        log.error("Invalid data format for last modified date: {}", schoolsReader.getDataLastModifiedDate(), e);
+        throw new UnableToIndexSchoolsException("Failed to parse last modified date from school data.", e);
+    }
 
     if (indexLastModified.isAfter(fileLastModified)) {
       log.info("Schools index more recent than file");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java
@@ -66,8 +66,8 @@ class SchoolIndexer {
       throw new UnableToIndexSchoolsException("Failed to parse last modified date from school data.", e);
     }
 
-    if (indexLastModified.isAfter(fileLastModified)) {
-      log.info("Schools index more recent than file");
+    if (indexLastModified.isAfter(fileLastModified) || indexLastModified.equals(fileLastModified)) {
+      log.info("Schools index is up to date");
       return;
     }
 


### PR DESCRIPTION
This pull request introduces changes to the `SchoolIndexer` class to improve the logic for checking whether the schools index needs updating based on file modification timestamps. Additionally, it includes minor import updates to support the new functionality.

### Enhancements to index update logic:

* Updated `indexSchoolsWithSearchProvider` to compare the last modified timestamps of the schools list file and the existing index. The method now skips reindexing if the index is more recent than the file. This prevents unnecessary reindexing and improves efficiency. (`src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java`, [src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.javaL53-R64](diffhunk://#diff-f51d83a975cffd5fc48272660a570a8f5ce894fa61ad01d151534992e98d704bL53-R64))

* Removed redundant file instantiation from the reindexing logic, as it is now handled earlier in the method. (`src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java`, [src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.javaL71](diffhunk://#diff-f51d83a975cffd5fc48272660a570a8f5ce894fa61ad01d151534992e98d704bL71))

### Supporting changes:

* Added `SchoolListReader` import to handle retrieval of the index's last modified date. (`src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java`, [src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.javaR30](diffhunk://#diff-f51d83a975cffd5fc48272660a570a8f5ce894fa61ad01d151534992e98d704bR30))

* Imported `java.time.Instant` to facilitate timestamp comparisons. (`src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java`, [src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.javaR19](diffhunk://#diff-f51d83a975cffd5fc48272660a570a8f5ce894fa61ad01d151534992e98d704bR19))