### PR TITLE
603/shav: survey-fix

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
@@ -49,7 +49,7 @@ public class IsaacEventPage extends Content {
 
   private List<ExternalReference> preResources;
   private List<Content> preResourceContent;
-  private List<ExternalReference> eventSurvey;
+  private ExternalReference eventSurvey;
 
   private String emailEventDetails;
 
@@ -119,7 +119,7 @@ public class IsaacEventPage extends Content {
                         @JsonProperty("location") final Location location,
                         @JsonProperty("preResources") final List<ExternalReference> preResources,
                         @JsonProperty("postResources") final List<ExternalReference> postResources,
-                        @JsonProperty("eventSurvey") final List<ExternalReference> eventSurvey,
+                        @JsonProperty("eventSurvey") final ExternalReference eventSurvey,
                         @JsonProperty("eventThumbnail") final Image eventThumbnail,
                         @JsonProperty("numberOfPlaces") final Integer numberOfPlaces,
                         @JsonProperty("EventStatus") final EventStatus eventStatus,
@@ -338,7 +338,7 @@ public class IsaacEventPage extends Content {
    *
    * @return the eventSurvey
    */
-  public List<ExternalReference> getEventSurvey() {
+  public ExternalReference getEventSurvey() {
     return eventSurvey;
   }
 
@@ -347,7 +347,7 @@ public class IsaacEventPage extends Content {
    *
    * @param eventSurvey the eventSurvey to set
    */
-  public void setEventSurvey(final List<ExternalReference> eventSurvey) {
+  public void setEventSurvey(final ExternalReference eventSurvey) {
     this.eventSurvey = eventSurvey;
   }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -57,7 +57,7 @@ public class IsaacEventPageDTO extends ContentDTO {
 
   private List<ExternalReference> postResources;
   private List<ContentDTO> postResourceContent;
-  private List<ExternalReference> eventSurvey;
+  private ExternalReference eventSurvey;
 
   private ImageDTO eventThumbnail;
 
@@ -127,7 +127,7 @@ public class IsaacEventPageDTO extends ContentDTO {
       @JsonProperty("location") final Location location,
       @JsonProperty("preResources") final List<ExternalReference> preResources,
       @JsonProperty("postResources") final List<ExternalReference> postResources,
-      @JsonProperty("eventSurvey") final List<ExternalReference> eventSurvey,
+      @JsonProperty("eventSurvey") final ExternalReference eventSurvey,
       @JsonProperty("eventThumbnail") final ImageDTO eventThumbnail,
       @JsonProperty("numberOfPlaces") final Integer numberOfPlaces,
       @JsonProperty("EventStatus") final EventStatus eventStatus,
@@ -320,7 +320,7 @@ public class IsaacEventPageDTO extends ContentDTO {
    * @return the eventSurvey
    */
   @JsonIgnore
-  public List<ExternalReference> getEventSurvey() {
+  public ExternalReference getEventSurvey() {
     return eventSurvey;
   }
 
@@ -330,7 +330,7 @@ public class IsaacEventPageDTO extends ContentDTO {
    * @param eventSurvey
    *            the eventSurvey to set
    */
-  public void setEventSurvey(final List<ExternalReference> eventSurvey) {
+  public void setEventSurvey(final ExternalReference eventSurvey) {
     this.eventSurvey = eventSurvey;
   }
 


### PR DESCRIPTION
Description: Updated the data types in both the DO & DTO pages for `eventSurvey` property from `List<External Reference>` to only `External Reference`
Ticket: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/603