### PR TITLE
Added second trigger for the sendEmailFeedback function

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -187,6 +187,7 @@ public final class Constants {
 
   public static final Integer EMAIL_EVENT_REMINDER_DAYS_AHEAD = 3;
   public static final Integer EMAIL_EVENT_FEEDBACK_DAYS_AGO = 60;
+  public static final Integer EMAIL_EVENT_SECOND_FEEDBACK_HOURS = 96;
 
   // Response messages
   public static final String EMPTY_ASSIGNMENT_GAMEBOARD =

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventNotificationEmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventNotificationEmailManager.java
@@ -200,26 +200,37 @@ public class EventNotificationEmailManager {
           // New logic for sending survey email
           String surveyUrl = event.getEventSurvey();
           String surveyTitle = event.getEventSurveyTitle();
+
           // Event end date (if present) is yesterday or before, else event date is yesterday, or before
-          // We want to send the event_feedback email 24 hours after the event
           boolean endDateYesterday =
               event.getEndDate() != null && event.getEndDate().isBefore(Instant.now().minus(1, ChronoUnit.DAYS));
-
           boolean noEndDateAndStartDateYesterday =
               event.getEndDate() == null && event.getDate().isBefore(Instant.now().minus(1, ChronoUnit.DAYS));
 
-          if (endDateYesterday || noEndDateAndStartDateYesterday) {
-            List<ExternalReference> postResources = event.getPostResources();
+          // Event end date (if present) is 96 hours ago or before, else event date is 96 hours ago or before
+          boolean endDate96HoursAgo =
+              event.getEndDate() != null && event.getEndDate()
+                  .isBefore(Instant.now().minus(Constants.EMAIL_EVENT_SECOND_FEEDBACK_HOURS, ChronoUnit.HOURS));
+          boolean noEndDateAndStartDate96HoursAgo =
+              event.getEndDate() == null && event.getDate()
+                  .isBefore(Instant.now().minus(Constants.EMAIL_EVENT_SECOND_FEEDBACK_HOURS, ChronoUnit.HOURS));
 
-            boolean postResourcesPresent =
-                postResources != null && !postResources.isEmpty() && !postResources.contains(null);
+          List<ExternalReference> postResources = event.getPostResources();
+          boolean postResourcesPresent =
+              postResources != null && !postResources.isEmpty() && !postResources.contains(null);
 
-            boolean eventSurveyTitleUrlPresent = (surveyUrl != null && !surveyUrl.isEmpty())
-                && (surveyTitle == null || !surveyTitle.isEmpty());
+          boolean eventSurveyTitleUrlPresent = (surveyUrl != null && !surveyUrl.isEmpty())
+              && (surveyTitle == null || !surveyTitle.isEmpty());
 
-            if (postResourcesPresent || eventSurveyTitleUrlPresent) {
-              commitAndSendFeedbackEmail(event, "post", "event_feedback");
-            }
+          // First trigger (24 hours)
+          if ((endDateYesterday || noEndDateAndStartDateYesterday) && (postResourcesPresent
+              || eventSurveyTitleUrlPresent)) {
+            commitAndSendFeedbackEmail(event, "post", "event_feedback");
+          }
+          // Second trigger (96 hours)
+          if ((endDate96HoursAgo || noEndDateAndStartDate96HoursAgo) && (postResourcesPresent
+              || eventSurveyTitleUrlPresent)) {
+            commitAndSendFeedbackEmail(event, "post", "event_feedback");
           }
         }
       }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -145,7 +145,7 @@ public final class Constants {
   public static final String SEGUE_CONFIG_LOCATION_NOT_SPECIFIED_MESSAGE =
       "Segue configuration location not specified, please provide it as either a java system property"
           + " (config.location) or environment variable SEGUE_CONFIG_LOCATION";
-
+  public static final Integer EMAIL_EVENT_SECOND_FEEDBACK_HOURS = 96;
   /**
    * Enum to describe types of server environment / profile.
    */

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -468,7 +468,7 @@ public class GitContentManager {
     return this.findByFieldNames(fieldsToMatch, startIndex, limit, sortInstructions, null);
   }
 
-  public final ResultsWrapper<ContentDTO> findByFieldNames(
+  public ResultsWrapper<ContentDTO> findByFieldNames(
       final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit,
       @Nullable final Map<String, Constants.SortOrder> sortInstructions,
       @Nullable final Map<String, AbstractFilterInstruction> filterInstructions

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventNotificationEmailManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventNotificationEmailManagerTest.java
@@ -1,0 +1,275 @@
+package uk.ac.cam.cl.dtg.isaac.api.managers;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.DATE_FIELDNAME;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.EMAIL_EVENT_FEEDBACK_DAYS_AGO;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.EVENT_TYPE;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.DEFAULT_MAX_WINDOW_SIZE;import static uk.ac.cam.cl.dtg.isaac.api.Constants.EMAIL_EVENT_SECOND_FEEDBACK_HOURS;
+
+import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
+
+import com.google.api.client.util.Maps;
+import com.google.common.collect.ImmutableList;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import junit.framework.AssertionFailedError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import uk.ac.cam.cl.dtg.isaac.dos.EventStatus;
+import uk.ac.cam.cl.dtg.isaac.dos.content.ExternalReference;
+import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.BookingStatus;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacEventPageDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.eventbookings.DetailedEventBookingDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryWithEmailAddressDTO;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
+import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
+import uk.ac.cam.cl.dtg.segue.comm.EmailManager;
+import uk.ac.cam.cl.dtg.segue.comm.EmailType;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
+import uk.ac.cam.cl.dtg.segue.search.AbstractFilterInstruction;
+import uk.ac.cam.cl.dtg.segue.search.DateRangeFilterInstruction;
+
+/**
+ * Unit tests for EventNotificationEmailManager.
+ */
+class EventNotificationEmailManagerTest {
+
+  private GitContentManager mockContentManager;
+  private EventBookingManager mockBookingManager;
+  private UserAccountManager mockUserAccountManager;
+  private EmailManager mockEmailManager;
+  private PgScheduledEmailManager mockPgScheduledEmailManager;
+  private EventNotificationEmailManager eventNotificationEmailManager;
+  private Object[] mockedObjects;
+
+  @BeforeEach
+  void setUp() {
+    mockContentManager = createMock(GitContentManager.class);
+    mockBookingManager = createMock(EventBookingManager.class);
+    mockUserAccountManager = createMock(UserAccountManager.class);
+    mockEmailManager = createMock(EmailManager.class);
+    mockPgScheduledEmailManager = createMock(PgScheduledEmailManager.class);
+
+    mockedObjects = new Object[]{
+        mockContentManager, mockBookingManager, mockUserAccountManager,
+        mockEmailManager, mockPgScheduledEmailManager
+    };
+
+    eventNotificationEmailManager = new EventNotificationEmailManager(
+        mockContentManager, mockBookingManager, mockUserAccountManager,
+        mockEmailManager, mockPgScheduledEmailManager
+    );
+  }
+
+  @Nested
+  class SendFeedbackEmails {
+
+    @Test
+    void sendFeedbackEmails_EventAt24HoursPostResources_SendsFeedbackEmail() throws Exception {
+      // Arrange
+      Instant eventDate = Instant.now().minus(24, ChronoUnit.HOURS); // 24 hours ago
+      IsaacEventPageDTO event = createTestEvent("event1", eventDate, null, EventStatus.FULLY_BOOKED);
+      event.setPostResources(ImmutableList.of(createExternalReference("resource1")));
+
+      List<DetailedEventBookingDTO> bookings = createAttendedBookings(event.getId(), 1);
+
+      setupContentManagerExpectations(Collections.singletonList(event));
+      setupBookingManagerExpectations(event.getId(), bookings, 1);
+      setupEmailSendingExpectations(event, "post", "event_feedback", 1, 1);
+
+      replay(mockedObjects);
+
+      // Act
+      assertDoesNotThrow(() -> eventNotificationEmailManager.sendFeedbackEmails());
+
+      // Assert
+      verify(mockedObjects);
+    }
+
+    @Test
+    void sendFeedbackEmails_EventAt96HoursWithPostResources_SendsFeedbackEmail() throws Exception {
+      // Arrange
+      Instant eventDate = Instant.now().minus(96, ChronoUnit.HOURS); // 96 hours ago
+      IsaacEventPageDTO event = createTestEvent("event96", eventDate, null, EventStatus.FULLY_BOOKED);
+      event.setPostResources(ImmutableList.of(createExternalReference("resource96")));
+
+      List<DetailedEventBookingDTO> bookings = createAttendedBookings(event.getId(), 1);
+
+      setupContentManagerExpectations(Collections.singletonList(event));
+      setupBookingManagerExpectations(event.getId(), bookings, 2);
+      setupEmailSendingExpectations(event, "post", "event_feedback", 1, 2);
+
+      replay(mockedObjects);
+
+      // Act
+      assertDoesNotThrow(() -> eventNotificationEmailManager.sendFeedbackEmails());
+
+      // Assert
+      verify(mockedObjects);
+    }
+
+    @Test
+    void sendFeedbackEmails_EventAt22Hours_DoesNotSendFeedbackEmail() throws Exception {
+      // Arrange
+      Instant eventDate = Instant.now().minus(22, ChronoUnit.HOURS); // 22 hours ago
+      IsaacEventPageDTO event = createTestEvent("event22", eventDate, null, EventStatus.FULLY_BOOKED);
+      event.setPostResources(ImmutableList.of(createExternalReference("resource22")));
+
+      List<DetailedEventBookingDTO> bookings = createAttendedBookings(event.getId(), 1);
+
+      setupContentManagerExpectations(Collections.singletonList(event));
+      setupBookingManagerExpectations(event.getId(), bookings, 0);
+
+      // Ensure no email is sent
+      expect(mockPgScheduledEmailManager.commitToSchedulingEmail(anyObject())).andThrow(new AssertionFailedError()).anyTimes();
+
+      replay(mockedObjects);
+
+      // Act
+      assertDoesNotThrow(() -> eventNotificationEmailManager.sendFeedbackEmails());
+
+      // Assert
+      verify(mockedObjects);
+    }
+
+    @Test
+    void sendFeedbackEmails_CancelledEvent_DoesNotSendFeedbackEmail() throws Exception {
+      // Arrange
+      Instant eventDate = Instant.now().minus(24, ChronoUnit.HOURS); // 24 hours ago
+      IsaacEventPageDTO event = createTestEvent("eventCancelled", eventDate, null, EventStatus.CANCELLED);
+      event.setPostResources(ImmutableList.of(createExternalReference("resourceCancelled")));
+
+      setupContentManagerExpectations(Collections.singletonList(event));
+
+      // Ensure no email is sent
+      expect(mockPgScheduledEmailManager.commitToSchedulingEmail(anyObject())).andThrow(new AssertionFailedError()).anyTimes();
+
+      replay(mockedObjects);
+
+      // Act
+      assertDoesNotThrow(() -> eventNotificationEmailManager.sendFeedbackEmails());
+
+      // Assert
+      verify(mockedObjects);
+    }
+  }
+
+  // Helper methods
+
+  private IsaacEventPageDTO createTestEvent(String id, Instant date, Instant endDate, EventStatus status) {
+    IsaacEventPageDTO event = new IsaacEventPageDTO();
+    event.setId(id);
+    event.setDate(date);
+    event.setEndDate(endDate);
+    event.setEventStatus(status);
+    event.setType(EVENT_TYPE);
+    return event;
+  }
+
+  private ExternalReference createExternalReference(String title) {
+    ExternalReference ref = new ExternalReference();
+    ref.setTitle(title);
+    ref.setUrl("https://example.com/" + title);
+    return ref;
+  }
+
+  private List<DetailedEventBookingDTO> createAttendedBookings(String eventId, int count) {
+    ImmutableList.Builder<DetailedEventBookingDTO> builder = ImmutableList.builder();
+    for (int i = 1; i <= count; i++) {
+      UserSummaryWithEmailAddressDTO user = new UserSummaryWithEmailAddressDTO();
+      user.setId((long) i);
+      user.setGivenName("User" + i);
+      user.setFamilyName("Test");
+      user.setEmail("user" + i + "@test.com");
+
+      DetailedEventBookingDTO booking = new DetailedEventBookingDTO();
+      booking.setUserBooked(user);
+      booking.setBookingStatus(BookingStatus.ATTENDED);
+      booking.setEventId(eventId);
+
+      builder.add(booking);
+    }
+    return builder.build();
+  }
+
+  private void setupContentManagerExpectations(List<IsaacEventPageDTO> events) throws ContentManagerException {
+    Map<String, List<String>> fieldsToMatch = Maps.newHashMap();
+    fieldsToMatch.put(TYPE_FIELDNAME, Collections.singletonList(EVENT_TYPE));
+
+    Map<String, Constants.SortOrder> sortInstructions = Maps.newHashMap();
+    sortInstructions.put(DATE_FIELDNAME, Constants.SortOrder.DESC);
+
+    Map<String, AbstractFilterInstruction> filterInstructions = Maps.newHashMap();
+    ZonedDateTime now = ZonedDateTime.now();
+    ZonedDateTime eventFeedbackThresholdDate = now.minusDays(EMAIL_EVENT_FEEDBACK_DAYS_AGO);
+    DateRangeFilterInstruction eventsWithinFeedbackDateRange = new DateRangeFilterInstruction(
+        eventFeedbackThresholdDate.toInstant(), Instant.now());
+    filterInstructions.put(DATE_FIELDNAME, eventsWithinFeedbackDateRange);
+
+    ResultsWrapper<ContentDTO> resultsWrapper = new ResultsWrapper<>((List<ContentDTO>) (List<?>) events, (long) events.size());
+
+    expect(mockContentManager.findByFieldNames(
+        anyObject(),
+        eq(0),
+        eq(DEFAULT_MAX_WINDOW_SIZE),
+        anyObject(),
+        anyObject()
+    )).andReturn(resultsWrapper);
+  }
+
+  private void setupBookingManagerExpectations(String eventId, List<DetailedEventBookingDTO> bookings, int callsCount)
+      throws SegueDatabaseException {
+    for (int i = 0; i < callsCount; i++) {
+      expect(mockBookingManager.adminGetBookingsByEventId(eventId)).andReturn(bookings);
+    }
+  }
+
+  private void setupEmailSendingExpectations(IsaacEventPageDTO event, String emailKeyPostfix,
+                                             String templateId, int userCount, int numberOfEmails) throws Exception {
+    String emailKey = event.getId() + "@" + emailKeyPostfix;
+
+    for (int i = 0; i < userCount; i++) {
+      RegisteredUserDTO user = new RegisteredUserDTO();
+      user.setId((long) (i + 1));
+      user.setGivenName("User" + (i + 1));
+      user.setFamilyName("Test");
+      user.setEmail("user" + (i + 1) + "@test.com");
+
+      //Multiple emails maybe sent for 96 hours in test (ONLY) but are stopped by infrastructure in production.
+      for(int j = 0; j < numberOfEmails; j++) {
+        expect(mockEmailManager.getEmailTemplateDTO(templateId)).andReturn(createEmailTemplate());
+        expect(mockUserAccountManager.getUserDTOById((long) (i + 1))).andReturn(user);
+        expect(mockPgScheduledEmailManager.commitToSchedulingEmail(emailKey)).andReturn(true);
+        mockEmailManager.sendTemplatedEmailToUser(eq(user), anyObject(), anyObject(), eq(EmailType.SYSTEM));
+      }
+      expectLastCall();
+    }
+  }
+
+  private uk.ac.cam.cl.dtg.isaac.dto.content.EmailTemplateDTO createEmailTemplate() {
+    uk.ac.cam.cl.dtg.isaac.dto.content.EmailTemplateDTO template =
+        new uk.ac.cam.cl.dtg.isaac.dto.content.EmailTemplateDTO();
+    template.setId("test-template");
+    template.setSubject("Test Subject");
+    template.setHtmlContent("<p>Test content</p>");
+    template.setPlainTextContent("Test content");
+    return template;
+  }
+}


### PR DESCRIPTION
This pull request adds a second trigger for sending event feedback emails to users. Previously, feedback emails were sent 24 hours after an event ended (or after the event date, if no end date existed). With this PR:

- Feedback emails are now sent twice: once at 24 hours and again at 96 hours (4 days) after the event ends.
- The code introduces a new constant for the 96-hour interval.
- The triggering logic in EventNotificationEmailManager is updated to handle both timings.
- Unit tests have been added to ensure emails are sent correctly at both 24 and 96 hours, and not sent for events that are too recent or cancelled.
- Minor code cleanup and method signature changes are included.
